### PR TITLE
Add writing style guide and DrupalCon blog post

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,6 @@ pnpm-debug.log*
 
 # macOS-specific files
 .DS_Store
+
+# Worktress
+.claude/worktrees

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,39 @@
+# Writing Style Guide for brianperry.dev
+
+When drafting or revising blog posts for this site, follow these guidelines to match Brian's voice.
+
+## Tone and Voice
+
+- Conversational and approachable — like talking to a knowledgeable friend, not writing a conference abstract.
+- Self-deprecating humor is a key ingredient. Don't overdo it, but a post without at least one moment of self-awareness probably needs another pass.
+- Be honest and direct about opinions. Brian doesn't hedge — he says what he thinks and owns it.
+- Personal and grounded. Even technical posts should feel like they're coming from a real person with a life outside of code.
+
+## Style
+
+- Parenthetical asides are a signature move. Use them for quick jokes, qualifications, or offhand commentary.
+- Short punchy sentences mixed with longer flowing ones. Vary the rhythm.
+- Don't be afraid of sentence fragments for emphasis.
+- Lists and bullet points are fine for organizing information, but add personality to individual items rather than keeping them dry.
+
+## Structure
+
+- Openings should be casual and direct. Get into it quickly.
+- Closings should have personality — a joke, a callback, or something memorable. Avoid generic sign-offs like "I'd love to connect."
+- Link back to other posts on the site when relevant. It adds context and makes the site feel connected.
+- Descriptions in frontmatter should be specific to the post content, not generic summaries.
+
+## Content
+
+- Weave in personal details naturally — family, hobbies, the Patriots, Nintendo, guitar, etc. These ground the writing and make it feel authentic.
+- When discussing technical topics, be practical and specific. Share real opinions rather than staying vague.
+- Don't be afraid to name what you don't know or haven't done yet. Brian is open about learning in public.
+- Pop culture references and analogies are welcome when they fit.
+
+## What to Avoid
+
+- Overly formal or corporate language.
+- Vague statements that could apply to anyone ("I'm excited about the future of X"). Get specific about why.
+- Trailing summaries that restate what was just said.
+- Generic descriptions or titles that don't reflect the actual content.
+- Excessive use of "I'm curious about" or "I'm looking forward to" without saying something concrete about why.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,1 @@
+@AGENTS.md

--- a/src/content/posts/2026/heading-back-to-drupalcon.md
+++ b/src/content/posts/2026/heading-back-to-drupalcon.md
@@ -1,0 +1,28 @@
+---
+title: "Heading Back to DrupalCon"
+description: "Returning to DrupalCon after a year away."
+author: Brian
+date: 2026-03-23
+---
+
+I'll be at DrupalCon Chicago this year, since it is right in my back yard.
+
+I've been away from the Drupal world for about a year now. Most of my time lately has been focused on building [Actual AI](https://actual.ai), working with AI tooling and spending time in the broader JS ecosystem. All good stuff, but it's meant that aside from continuing to maintain the [API Client](https://www.drupal.org/project/api_client), Drupal has been in my periphery rather than front and center.
+
+DrupalCon is a good moment to change that - to check back in with a project and community I care about, see where things have headed, and reconnect with people I haven't seen in a while.
+
+A few things I'm particularly curious about:
+
+### How the project is thinking about AI
+
+This is the thing I'm most eager to dig into. I've spent a lot of the past year building with LLMs - building agents, wiring AI into personal workflows, working on [Actual AI](https://actual.ai). I'm curious how Drupal is approaching AI integration, what's landed, what's still being figured out, and where the interesting open problems are.
+
+### Getting hands on with Drupal Canvas and code components
+
+While I did follow along with early development, I haven't had a chance to get hands on with the stable release. I'm especially interested in experimenting with code components since [the Drupal JSON:API Client](https://www.npmjs.com/package/@drupal-api-client/json-api-client) is available out of the box for use in Canvas. This is likely what I'll be focusing on during contribution day if anyone is interested in collaborating.
+
+### Sharing what I've been working on
+
+Part of coming back is bringing back what I've learned. I'm looking forward to conversations about what building with AI actually looks like day-to-day, and what any of that might mean for Drupal.
+
+A big thank you to [MidCamp](https://www.midcamp.org/) for providing my ticket. If you're going to be there, I'd love to connect.

--- a/src/content/posts/2026/heading-back-to-drupalcon.md
+++ b/src/content/posts/2026/heading-back-to-drupalcon.md
@@ -1,28 +1,28 @@
 ---
 title: "Heading Back to DrupalCon"
-description: "Returning to DrupalCon after a year away."
+description: "Returning to DrupalCon after a year away — what I'm curious about, what I want to share, and what I'm looking forward to."
 author: Brian
 date: 2026-03-23
 ---
 
-I'll be at DrupalCon Chicago this year, since it is right in my back yard.
+I'll be at DrupalCon Chicago this year. It's right in my back yard, so I really have no excuse not to show up.
 
-I've been away from the Drupal world for about a year now. Most of my time lately has been focused on building [Actual AI](https://actual.ai), working with AI tooling and spending time in the broader JS ecosystem. All good stuff, but it's meant that aside from continuing to maintain the [API Client](https://www.drupal.org/project/api_client), Drupal has been in my periphery rather than front and center.
+I've been away from the Drupal world for about a year now. Most of my time lately has been focused on building [Actual AI](https://actual.ai), working with AI tooling, and spending time in the broader JS ecosystem. All good stuff, but it's meant that aside from continuing to maintain the [API Client](https://www.drupal.org/project/api_client), Drupal has been in my periphery rather than front and center. I wrote a bit about how that happened in my [last post](/posts/2026/its-been-a-while), and honestly it still feels a little weird to have drifted from something that was such a huge part of my professional life for so long.
 
-DrupalCon is a good moment to change that - to check back in with a project and community I care about, see where things have headed, and reconnect with people I haven't seen in a while.
+DrupalCon is a good moment to change that — to check back in with a project and community I care about, see where things have headed, and reconnect with people I haven't seen in a while.
 
 A few things I'm particularly curious about:
 
 ### How the project is thinking about AI
 
-This is the thing I'm most eager to dig into. I've spent a lot of the past year building with LLMs - building agents, wiring AI into personal workflows, working on [Actual AI](https://actual.ai). I'm curious how Drupal is approaching AI integration, what's landed, what's still being figured out, and where the interesting open problems are.
+This is the thing I'm most eager to dig into. I've spent a lot of the past year building with LLMs — building agents, wiring AI into personal workflows, working on [Actual AI](https://actual.ai). I'm curious how Drupal is approaching AI integration, what's landed, what's still being figured out, and where the interesting open problems are.
 
 ### Getting hands on with Drupal Canvas and code components
 
-While I did follow along with early development, I haven't had a chance to get hands on with the stable release. I'm especially interested in experimenting with code components since [the Drupal JSON:API Client](https://www.npmjs.com/package/@drupal-api-client/json-api-client) is available out of the box for use in Canvas. This is likely what I'll be focusing on during contribution day if anyone is interested in collaborating.
+I followed along with early development, but I haven't actually gotten my hands dirty with the stable release yet. I'm especially interested in experimenting with code components since [the Drupal JSON:API Client](https://www.npmjs.com/package/@drupal-api-client/json-api-client) is available out of the box for use in Canvas. This is likely what I'll be focusing on during contribution day if anyone is interested in collaborating (or just wants to hang out.)
 
 ### Sharing what I've been working on
 
-Part of coming back is bringing back what I've learned. I'm looking forward to conversations about what building with AI actually looks like day-to-day, and what any of that might mean for Drupal.
+Part of coming back is bringing back what I've learned. Building with AI day-to-day has changed how I think about a lot of things — how I prototype, how I approach problems, what I'm willing to attempt. I'm looking forward to conversations about what that actually looks like in practice, and whether any of it maps back to Drupal in useful ways. At a minimum I'll have some strong opinions and wild demos to share.
 
-A big thank you to [MidCamp](https://www.midcamp.org/) for providing my ticket. If you're going to be there, I'd love to connect.
+A big thank you to [MidCamp](https://www.midcamp.org/) for providing my ticket. If you're going to be there, come say hi. I'll be the one who looks like they have forgotten how the LAMP stack works.


### PR DESCRIPTION
## Changes

- **AGENTS.md**: New writing style guide documenting Brian's voice and conventions for blog posts (conversational tone, self-deprecating humor, parenthetical asides, etc.)
- **CLAUDE.md**: New configuration file referencing AGENTS.md
- **Blog post**: Added "Heading Back to DrupalCon" for 2026 covering return to the Drupal community, AI integration interests, and Canvas experimentation plans
- **.gitignore**: Added worktrees exclusion for local development

## Summary

Added documentation and tooling for consistent writing style, plus a new blog post about returning to DrupalCon Chicago after a year focused on AI and the JavaScript ecosystem.