### PR TITLE
Apply "Broadcast" redesign concept across the site

### DIFF
--- a/src/components/BaseHead.astro
+++ b/src/components/BaseHead.astro
@@ -6,6 +6,7 @@ import { ViewTransitions } from "astro:transitions";
 import "open-props/open-props.min.css";
 import "open-props/normalize.min.css";
 import "../styles/global.css";
+import "../styles/broadcast.css";
 
 declare global {
   interface Window {
@@ -40,20 +41,12 @@ const { title, description, image = "/og_image.jpg" } = Astro.props;
 <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
 <meta name="generator" content={Astro.generator} />
 
-<!-- Font preloads -->
+<!-- Fonts: Broadcast concept — Alfa Slab One (display), Libre Franklin (body), Space Mono (kickers) -->
+<link rel="preconnect" href="https://fonts.googleapis.com" />
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
 <link
-  rel="preload"
-  href="/fonts/atkinson-regular.woff"
-  as="font"
-  type="font/woff"
-  crossorigin
-/>
-<link
-  rel="preload"
-  href="/fonts/atkinson-bold.woff"
-  as="font"
-  type="font/woff"
-  crossorigin
+  href="https://fonts.googleapis.com/css2?family=Alfa+Slab+One&family=Libre+Franklin:wght@400;500;600;700;800&family=Space+Mono:wght@400;700&display=swap"
+  rel="stylesheet"
 />
 
 <!-- Canonical URL -->

--- a/src/components/Footer.astro
+++ b/src/components/Footer.astro
@@ -1,51 +1,22 @@
-<footer>
-  Made with 🥯 by Brian Perry.
-  <div class="social-links">
-    <a href="https://bsky.app/profile/brianperry.dev" target="_blank">
-      <span class="sr-only">Follow me on Bluesky</span>
-      <svg xmlns="http://www.w3.org/2000/svg" aria-hidden="true" width="32" height="32" viewBox="0 0 576 512"><path fill="currentColor" d="M407.8 294.7c-3.3-.4-6.7-.8-10-1.3c3.4.4 6.7.9 10 1.3M288 227.1c-26.1-50.7-97.1-145.2-163.1-191.8C61.6-9.4 37.5-1.7 21.6 5.5C3.3 13.8 0 41.9 0 58.4S9.1 194 15 213.9c19.5 65.7 89.1 87.9 153.2 80.7c3.3-.5 6.6-.9 10-1.4c-3.3.5-6.6 1-10 1.4c-93.9 14-177.3 48.2-67.9 169.9C220.6 589.1 265.1 437.8 288 361.1c22.9 76.7 49.2 222.5 185.6 103.4c102.4-103.4 28.1-156-65.8-169.9c-3.3-.4-6.7-.8-10-1.3c3.4.4 6.7.9 10 1.3c64.1 7.1 133.6-15.1 153.2-80.7C566.9 194 576 75 576 58.4s-3.3-44.7-21.6-52.9c-15.8-7.1-40-14.9-103.2 29.8C385.1 81.9 314.1 176.4 288 227.1"/></svg>
-    </a>
-    <a href="https://github.com/backlineint" target="_blank">
-      <span class="sr-only">Go to my GitHub profile</span>
-      <svg
-        viewBox="0 0 16 16"
-        aria-hidden="true"
-        width="32"
-        height="32"
-        astro-icon="social/github"
-        ><path
-          fill="currentColor"
-          d="M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82.64-.18 1.32-.27 2-.27.68 0 1.36.09 2 .27 1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55.38A8.012 8.012 0 0 0 16 8c0-4.42-3.58-8-8-8z"
-        ></path></svg
-      >
-    </a>
-  </div>
-  <div class="internal-links">
-    <a href="/feed.xml">Feed</a> •
-    <a href="/style-guide">Style Guide</a>
+<footer class="foot">
+  <svg class="clouds" viewBox="0 0 1280 120" preserveAspectRatio="none" aria-hidden="true">
+    <path d="M0 120 V70 C90 40 150 78 210 60 C270 42 320 70 400 52 C470 36 520 74 600 60 C680 46 720 30 800 54 C880 78 930 44 1010 58 C1090 72 1140 40 1210 60 C1240 68 1265 58 1280 64 V120 Z" fill="#141a3a"></path>
+    <path d="M0 120 V92 C120 70 190 96 280 82 C380 66 440 92 540 84 C650 75 720 58 820 80 C930 104 980 74 1080 86 C1160 96 1220 78 1280 88 V120 Z" fill="#1a2249"></path>
+  </svg>
+  <div class="foot-inner">
+    <div class="made">Made with 🥯 by <b>Brian Perry</b>.</div>
+    <div class="social">
+      <a href="https://bsky.app/profile/brianperry.dev" target="_blank" aria-label="Bluesky">
+        <span class="sr-only">Follow me on Bluesky</span>
+        <svg xmlns="http://www.w3.org/2000/svg" aria-hidden="true" viewBox="0 0 576 512"><path fill="currentColor" d="M407.8 294.7c-3.3-.4-6.7-.8-10-1.3c3.4.4 6.7.9 10 1.3M288 227.1c-26.1-50.7-97.1-145.2-163.1-191.8C61.6-9.4 37.5-1.7 21.6 5.5C3.3 13.8 0 41.9 0 58.4S9.1 194 15 213.9c19.5 65.7 89.1 87.9 153.2 80.7c3.3-.5 6.6-.9 10-1.4c-3.3.5-6.6 1-10 1.4c-93.9 14-177.3 48.2-67.9 169.9C220.6 589.1 265.1 437.8 288 361.1c22.9 76.7 49.2 222.5 185.6 103.4c102.4-103.4 28.1-156-65.8-169.9c-3.3-.4-6.7-.8-10-1.3c3.4.4 6.7.9 10 1.3c64.1 7.1 133.6-15.1 153.2-80.7C566.9 194 576 75 576 58.4s-3.3-44.7-21.6-52.9c-15.8-7.1-40-14.9-103.2 29.8C385.1 81.9 314.1 176.4 288 227.1"/></svg>
+      </a>
+      <a href="https://github.com/backlineint" target="_blank" aria-label="GitHub">
+        <span class="sr-only">Go to my GitHub profile</span>
+        <svg viewBox="0 0 16 16" aria-hidden="true"><path fill="currentColor" d="M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82.64-.18 1.32-.27 2-.27.68 0 1.36.09 2 .27 1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55.38A8.012 8.012 0 0 0 16 8c0-4.42-3.58-8-8-8z"></path></svg>
+      </a>
+    </div>
+    <div class="botlinks">
+      <a href="/feed.xml">Feed</a><span>·</span><a href="/style-guide">Style Guide</a>
+    </div>
   </div>
 </footer>
-<style>
-  footer {
-    padding: 2em 1em 2.5em 1em;
-    background: var(--surface-2);
-    color: var(--text-2);
-    text-align: center;
-  }
-  .social-links {
-    display: flex;
-    justify-content: center;
-    gap: 1em;
-    margin-top: 1em;
-  }
-  .social-links a {
-    text-decoration: none;
-    color: var(--text-2);
-  }
-  .social-links a:hover {
-    color: var(--text-1);
-  }
-  .internal-links {
-    margin-top: var(--size-3);
-  }
-</style>

--- a/src/components/Header.astro
+++ b/src/components/Header.astro
@@ -1,81 +1,22 @@
 ---
 import HeaderLink from "./HeaderLink.astro";
-import { SITE_TITLE } from "../consts";
 ---
 
-<header>
-  <nav>
-    <h2><a href="/">{SITE_TITLE}</a></h2>
-    <div class="internal-links">
-      <HeaderLink href="/posts">Posts</HeaderLink>
-      <HeaderLink href="/about">About</HeaderLink>
-    </div>
-    <div class="social-links">
-      <a href="https://bsky.app/profile/brianperry.dev" target="_blank">
-        <span class="sr-only">Follow me on Bluesky</span>
-        <svg xmlns="http://www.w3.org/2000/svg" aria-hidden="true" width="32" height="32" viewBox="0 0 576 512"><path fill="currentColor" d="M407.8 294.7c-3.3-.4-6.7-.8-10-1.3c3.4.4 6.7.9 10 1.3M288 227.1c-26.1-50.7-97.1-145.2-163.1-191.8C61.6-9.4 37.5-1.7 21.6 5.5C3.3 13.8 0 41.9 0 58.4S9.1 194 15 213.9c19.5 65.7 89.1 87.9 153.2 80.7c3.3-.5 6.6-.9 10-1.4c-3.3.5-6.6 1-10 1.4c-93.9 14-177.3 48.2-67.9 169.9C220.6 589.1 265.1 437.8 288 361.1c22.9 76.7 49.2 222.5 185.6 103.4c102.4-103.4 28.1-156-65.8-169.9c-3.3-.4-6.7-.8-10-1.3c3.4.4 6.7.9 10 1.3c64.1 7.1 133.6-15.1 153.2-80.7C566.9 194 576 75 576 58.4s-3.3-44.7-21.6-52.9c-15.8-7.1-40-14.9-103.2 29.8C385.1 81.9 314.1 176.4 288 227.1"/></svg>
-      </a>
-      <a href="https://github.com/backlineint" target="_blank">
-        <span class="sr-only">My GitHub profile</span>
-        <svg viewBox="0 0 16 16" aria-hidden="true" width="32" height="32"
-          ><path
-            fill="currentColor"
-            d="M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82.64-.18 1.32-.27 2-.27.68 0 1.36.09 2 .27 1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55.38A8.012 8.012 0 0 0 16 8c0-4.42-3.58-8-8-8z"
-          ></path></svg
-        >
-      </a>
-    </div>
-  </nav>
-</header>
-<style>
-  header {
-    margin: 0;
-    padding: 0 1em;
-    background: var(--surface-2);
-    box-shadow: 0 2px 8px rgba(var(--black), 5%);
-  }
-  h2 {
-    margin: 0;
-    font-size: var(--font-size-4);
-    @media (min-width: 720px) {
-      font-size: var(--font-size-5);
-    }
-  }
-
-  h2 a,
-  h2 a.active {
-    text-decoration: none;
-  }
-  nav {
-    display: flex;
-    align-items: center;
-    justify-content: space-between;
-  }
-  nav a {
-    padding: 1em 0.5em;
-    margin-block: 0;
-    margin-inline: 0;
-    color: var(--black);
-    border-bottom: 4px solid transparent;
-    text-decoration: none;
-  }
-  nav a.active {
-    text-decoration: none;
-    border-bottom-color: var(--accent);
-  }
-  .social-links,
-  .social-links a {
-    display: flex;
-  }
-  @media (max-width: 720px) {
-    .social-links {
-      display: none;
-    }
-  }
-  @media (min-width: 720px) {
-    .internal-links {
-      position: relative;
-      right: var(--size-8);
-    }
-  }
-</style>
+<nav class="nav">
+  <a class="brand" href="/">brian<b>perry</b>.dev</a>
+  <div class="links">
+    <HeaderLink href="/posts">Writing</HeaderLink>
+    <HeaderLink href="/about">About</HeaderLink>
+    <HeaderLink href="/feed.xml">Feed</HeaderLink>
+  </div>
+  <div class="ico">
+    <a href="https://bsky.app/profile/brianperry.dev" target="_blank" aria-label="Bluesky">
+      <span class="sr-only">Follow me on Bluesky</span>
+      <svg xmlns="http://www.w3.org/2000/svg" aria-hidden="true" viewBox="0 0 576 512"><path fill="currentColor" d="M407.8 294.7c-3.3-.4-6.7-.8-10-1.3c3.4.4 6.7.9 10 1.3M288 227.1c-26.1-50.7-97.1-145.2-163.1-191.8C61.6-9.4 37.5-1.7 21.6 5.5C3.3 13.8 0 41.9 0 58.4S9.1 194 15 213.9c19.5 65.7 89.1 87.9 153.2 80.7c3.3-.5 6.6-.9 10-1.4c-3.3.5-6.6 1-10 1.4c-93.9 14-177.3 48.2-67.9 169.9C220.6 589.1 265.1 437.8 288 361.1c22.9 76.7 49.2 222.5 185.6 103.4c102.4-103.4 28.1-156-65.8-169.9c-3.3-.4-6.7-.8-10-1.3c3.4.4 6.7.9 10 1.3c64.1 7.1 133.6-15.1 153.2-80.7C566.9 194 576 75 576 58.4s-3.3-44.7-21.6-52.9c-15.8-7.1-40-14.9-103.2 29.8C385.1 81.9 314.1 176.4 288 227.1"/></svg>
+    </a>
+    <a href="https://github.com/backlineint" target="_blank" aria-label="GitHub">
+      <span class="sr-only">My GitHub profile</span>
+      <svg viewBox="0 0 16 16" aria-hidden="true"><path fill="currentColor" d="M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82.64-.18 1.32-.27 2-.27.68 0 1.36.09 2 .27 1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55.38A8.012 8.012 0 0 0 16 8c0-4.42-3.58-8-8-8z"></path></svg>
+    </a>
+  </div>
+</nav>

--- a/src/components/HeaderLink.astro
+++ b/src/components/HeaderLink.astro
@@ -12,13 +12,3 @@ const isActive = href === pathname || href === pathname.replace(/\/$/, '');
 <a href={href} class:list={[className, { active: isActive }]} {...props}>
 	<slot />
 </a>
-<style>
-	a {
-		display: inline-block;
-		text-decoration: none;
-	}
-	a.active {
-		font-weight: bolder;
-		text-decoration: underline;
-	}
-</style>

--- a/src/components/rad/RadPostTeaser.astro
+++ b/src/components/rad/RadPostTeaser.astro
@@ -10,62 +10,35 @@ type Props = {
     | CollectionEntry<"jams">;
 };
 
-const { title, date, description, imagePath, alt } = Astro.props.post.data;
+const { title, date, description, imagePath, alt, tags } = Astro.props.post.data;
 const { collection, slug } = Astro.props.post;
+const href = `/${collection}/${slug}`;
 ---
 
-<rad-post-teaser>
+<article class:list={["row", { noimg: !imagePath }]}>
+  <div>
+    <div class="kicker rk">
+      <FormattedDate date={new Date(date)} />
+    </div>
+    <h3>
+      <a href={href}>{title} <span class="arr">→</span></a>
+    </h3>
+    <p>{description}</p>
+    {
+      tags && tags.length > 0 && (
+        <div class="tags">
+          {tags.map((tag) => (
+            <span class="tag">{tag}</span>
+          ))}
+        </div>
+      )
+    }
+  </div>
   {
     imagePath && (
-      <Image src={imagePath} alt={alt ? alt : null} width="672" height="378" />
+      <a href={href} class="thumb">
+        <Image src={imagePath} alt={alt ? alt : ""} width="336" height="231" />
+      </a>
     )
   }
-  <div class="text">
-    <h4 class="title">
-      <a href={`/${collection}/${slug}`}>
-        {title}
-      </a>
-    </h4>
-    <p class="date">
-      <FormattedDate date={new Date(date)} />
-    </p>
-    <p>
-      {description}
-    </p>
-    <a href={`/${collection}/${slug}`}>Read more →</a>
-  </div>
-</rad-post-teaser>
-
-<style>
-  rad-post-teaser {
-    @media (min-width: 720px) {
-      display: flex;
-      justify-content: space-between;
-    }
-    & .title {
-      margin: 0;
-      color: var(--text-1);
-      line-height: 1;
-    }
-    & .date {
-      margin: 0;
-      color: var(--text-2);
-    }
-    & img {
-      margin: 0 0 var(--size-7) 0;
-      box-shadow: var(--box-shadow);
-      border-radius: 12px;
-      aspect-ratio: 16 / 9;
-      object-fit: cover;
-      @media (min-width: 720px) {
-        width: 35%;
-        margin: 0 0 0 var(--size-3);
-      }
-    }
-  }
-  rad-post-teaser:has(img) {
-    @media (min-width: 720px) {
-      flex-direction: row-reverse;
-    }
-  }
-</style>
+</article>

--- a/src/layouts/MarkdownPage.astro
+++ b/src/layouts/MarkdownPage.astro
@@ -24,82 +24,31 @@ const { frontmatter } = Astro.props;
       description={frontmatter.description}
       image={frontmatter.heroImage}
     />
-    <style>
-      main {
-        width: 100%;
-        max-width: 100%;
-        margin: 0;
-        padding: var(--size-3);
-      }
-      .hero-image {
-        width: 100%;
-        margin-top: var(--size-7);
-      }
-      .hero-image img {
-        display: block;
-        margin: 0 auto;
-        border-radius: 12px;
-        box-shadow: var(--box-shadow);
-        aspect-ratio: 16 / 9;
-        object-fit: cover;
-        &.top {
-          object-position: top;
-        }
-      }
-      .prose {
-        width: 760px;
-        max-width: 100%;
-        margin: auto;
-        padding: 1em;
-        img {
-          box-shadow: var(--box-shadow);
-        }
-      }
-      .title {
-        margin-bottom: 1em;
-        padding: 1em 0;
-        text-align: center;
-        line-height: 1;
-      }
-      .title h1 {
-        margin: 0 0 0.5em 0;
-      }
-      .date {
-        margin-bottom: 0.5em;
-        color: var(--text-2);
-      }
-      .last-updated-on {
-        font-style: italic;
-      }
-    </style>
   </head>
 
   <body>
     <Header />
     <main>
-      <article>
+      <article class="article">
+        <h1 class="title">{frontmatter.title}</h1>
+
         {
           frontmatter.heroImage && (
-            <div class="hero-image">
+            <div class="post-hero">
               <img
                 width={1020}
                 height={510}
                 src={frontmatter.heroImage}
                 alt={frontmatter.alt}
-                class={
-                  frontmatter.imageAlignment
-                    ? frontmatter.imageAlignment
-                    : "center"
-                }
+                class={frontmatter.imageAlignment ? frontmatter.imageAlignment : "center"}
               />
             </div>
           )
         }
+
+        <hr class="rule" />
+
         <div class="prose">
-          <div class="title">
-            <h1>{frontmatter.title}</h1>
-            <hr />
-          </div>
           <slot />
         </div>
       </article>

--- a/src/layouts/Post.astro
+++ b/src/layouts/Post.astro
@@ -23,83 +23,38 @@ const { title, description, pubDate, updatedDate, heroImage } = Astro.props;
       description={description ? description : "brianperry.dev"}
       image={heroImage}
     />
-    <style>
-      main {
-        width: 100%;
-        max-width: 100%;
-        margin: 0;
-        padding: var(--size-3);
-      }
-      .hero-image {
-        width: 100%;
-        margin-top: var(--size-7);
-      }
-      .hero-image img {
-        display: block;
-        margin: 0 auto;
-        border-radius: 12px;
-        box-shadow: var(--box-shadow);
-        aspect-ratio: 16 / 9;
-        object-fit: cover;
-      }
-      .prose {
-        width: 760px;
-        max-width: 100%;
-        margin: auto;
-        padding: 1em;
-        img {
-          box-shadow: var(--box-shadow);
-        }
-        & :where(li, dd, figcaption) {
-          max-inline-size: none;
-        }
-      }
-      .title {
-        margin-bottom: 1em;
-        padding: 1em 0;
-        text-align: center;
-        line-height: 1;
-      }
-      .title h1 {
-        margin: 0 0 0.5em 0;
-      }
-      .date {
-        margin-bottom: 0.5em;
-        color: var(--text-2);
-      }
-      .last-updated-on {
-        font-style: italic;
-      }
-    </style>
   </head>
 
   <body>
     <Header />
     <main>
-      <article>
+      <article class="article">
+        <a href="/posts" class="backlink mono">← all writing</a>
+
+        <h1 class="title">{title}</h1>
+
+        <div class="kicker post-meta">
+          <FormattedDate date={new Date(pubDate)} />
+          {
+            updatedDate && (
+              <span class="last-updated-on">
+                · updated <FormattedDate date={new Date(updatedDate)} />
+              </span>
+            )
+          }
+        </div>
+
         {
           heroImage && (
-            <div class="hero-image">
+            <div class="post-hero">
               <img width={1020} height={510} src={heroImage} alt="" />
             </div>
           )
         }
+
+        <hr class="rule" />
+
         <div class="prose">
-          <div class="title">
-            <div class="date">
-              <FormattedDate date={new Date(pubDate)} />
-              {
-                updatedDate && (
-                  <div class="last-updated-on">
-                    Last updated on{" "}
-                    <FormattedDate date={new Date(updatedDate)} />
-                  </div>
-                )
-              }
-            </div>
-            <h1>{title}</h1>
-            <hr />
-          </div>
           <slot />
         </div>
       </article>

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -1,17 +1,13 @@
 ---
-import { Image } from "astro:assets";
 import { getSortedPosts } from "../lib/getSortedPosts";
 import { SITE_TITLE, SITE_DESCRIPTION } from "../consts";
 
 import BaseHead from "../components/BaseHead.astro";
 import Header from "../components/Header.astro";
 import Footer from "../components/Footer.astro";
-import RadTwoCol from "../components/rad/RadTwoCol.astro";
 import RadPostTeaser from "../components/rad/RadPostTeaser.astro";
 
-import homeImage from "../assets/perry_weather.jpg";
-
-const posts = await getSortedPosts(4);
+const posts = await getSortedPosts(3);
 ---
 
 <!doctype html>
@@ -20,134 +16,98 @@ const posts = await getSortedPosts(4);
     <BaseHead title={SITE_TITLE} description={SITE_DESCRIPTION} />
   </head>
   <body>
-    <Header title={SITE_TITLE} />
-    <main>
-      <RadTwoCol>
-        <div class="primary">
-          <h1>BrianPerry.dev</h1>
-          <h2 class="subhead">A serious and professional website</h2>
-          <p>
-            I'm a <a href="https://github.com/backlineint">web developer</a>
-            and a <a href="https://www.drupal.org/u/brianperry"
-              >member of the Drupal community</a
-            > who often <a href="https://noti.st/brianperry">presents</a> at tech
-            events. I live with a super awesome family in the Chicago suburbs and
-            I really like Nintendo.
-          </p>
-          <h3>Latest Posts</h3>
-          <ul>
-            {
-              posts.map((entry) => (
-                <li>
-                  <RadPostTeaser post={entry} />
-                </li>
-              ))
-            }
-          </ul>
-        </div>
-        <div class="secondary">
-          <Image
-            src={homeImage}
-            alt="Brian with a weather station"
-            class="home-image"
-          />
-          <h3>Recent Projects</h3>
-          <ul>
-            <li>
-              <a href="https://actual.ai"
-                >Actual AI</a
-              > - Guardrails for AI-Powered Software Development
-            </li>
-            <li>
-              Stealth Read Later App - Side project city. More to come soon.
-            </li>
-          </ul>
-          <h3>Currently Enjoying</h3>
-          <ul>
-            <li>
-              <a href="/posts/2026/2026-oscars-films/">2026 Oscars Films</a> - unusually crowd pleasing list this year.
-            </li>
-            <li>
-              <a href="https://www.residentevil.com/requiem/en-us/">Resident Evil Requiem</a> - enjoying playing this like a total wuss and saving every five seconds. Runs great on Switch 2.
-            </li>
-            <li>
-              <a href="https://www.nintendo.com/us/store/products/pokemon-pokopia-switch-2">Pokopia</a> - Scratching the Animal Crossing itch. Also the perfect cozy game balance to Resident Evil.
-            </li>
-            <li>
-              <a href="https://www.youtube.com/playlist?list=PLcZMZxR9uxC8Wgves165_y4Kakqq5F5hZ">I Used to Go to This Bar - Joyce Manor</a> - perfect 19 minute punk album
-            </li>
-          </ul>
-        </div>
-      </RadTwoCol>
-    </main>
-    <Footer />
-    <style>
-      main {
-        width: 1250px;
-      }
-      img {
-        box-shadow: var(--box-shadow);
-        &.home-image {
-          @media (max-width: 1024px) {
-            width: 100%;
-            max-width: var(--size-content-2);
-            margin: var(--size-3) auto var(--size-7) auto;
-          }
-        }
-      }
-      :where(li) {
-        padding-inline-start: 0;
-      }
-      :where(li) {
-        max-inline-size: unset;
-      }
-      h3 {
-        margin: var(--size-5) 0 var(--size-5) 0;
-      }
+    <Header />
 
-      .primary {
-        & h2.subhead {
-          font-size: var(--font-size-5);
-          line-height: var(--font-lineheight-2);
+    <svg class="rings" width="1100" height="900" style="top:60px" viewBox="0 0 1100 900" aria-hidden="true">
+      <circle cx="550" cy="240" r="220"></circle><circle cx="550" cy="240" r="340"></circle>
+      <circle cx="550" cy="240" r="470"></circle><circle cx="550" cy="240" r="600"></circle>
+    </svg>
+
+    <header class="hero wrap">
+      <span class="pill">A serious &amp; professional website</span>
+      <h1 class="mast">Brian<span class="l2">Perry.dev</span></h1>
+      <p class="bio">
+        I'm a <a href="https://github.com/backlineint">web developer</a> and a
+        <a href="https://www.drupal.org/u/brianperry">member of the Drupal community</a>
+        who often <a href="https://noti.st/brianperry">presents</a> at tech events.
+        I live with a super awesome family in the Chicago suburbs and I really like Nintendo.
+      </p>
+
+      <div class="findme">
+        <a href="https://bsky.app/profile/brianperry.dev" target="_blank">
+          <svg viewBox="0 0 576 512" aria-hidden="true"><path d="M407.8 294.7c-3.3-.4-6.7-.8-10-1.3c3.4.4 6.7.9 10 1.3M288 227.1c-26.1-50.7-97.1-145.2-163.1-191.8C61.6-9.4 37.5-1.7 21.6 5.5C3.3 13.8 0 41.9 0 58.4S9.1 194 15 213.9c19.5 65.7 89.1 87.9 153.2 80.7c3.3-.5 6.6-.9 10-1.4c-3.3.5-6.6 1-10 1.4c-93.9 14-177.3 48.2-67.9 169.9C220.6 589.1 265.1 437.8 288 361.1c22.9 76.7 49.2 222.5 185.6 103.4c102.4-103.4 28.1-156-65.8-169.9c-3.3-.4-6.7-.8-10-1.3c3.4.4 6.7.9 10 1.3c64.1 7.1 133.6-15.1 153.2-80.7C566.9 194 576 75 576 58.4s-3.3-44.7-21.6-52.9c-15.8-7.1-40-14.9-103.2 29.8C385.1 81.9 314.1 176.4 288 227.1"/></svg>Bluesky
+        </a>
+        <a href="https://github.com/backlineint" target="_blank">
+          <svg viewBox="0 0 16 16" aria-hidden="true"><path d="M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82.64-.18 1.32-.27 2-.27.68 0 1.36.09 2 .27 1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55.38A8.012 8.012 0 0 0 16 8c0-4.42-3.58-8-8-8z"/></svg>GitHub
+        </a>
+        <a href="/feed.xml">
+          <svg viewBox="0 0 24 24" aria-hidden="true"><path d="M5 19a2 2 0 1 0 0-4 2 2 0 0 0 0 4ZM3 9.5V13c4.4 0 8 3.6 8 8h3.5C14.5 14.6 9.4 9.5 3 9.5Zm0-6V7c7.7 0 14 6.3 14 14h3.5C20.5 11.6 12.4 3.5 3 3.5Z"/></svg>RSS
+        </a>
+      </div>
+    </header>
+
+    <main class="wrap">
+      <div class="sec-head">
+        <h2>Latest</h2>
+        <span class="count">writing · recent</span>
+      </div>
+
+      <ul class="rows">
+        {
+          posts.map((entry) => (
+            <li>
+              <RadPostTeaser post={entry} />
+            </li>
+          ))
         }
-        /* TODO: Abstract list styles into a list component */
-        & ul {
-          display: flex;
-          flex-wrap: wrap;
-          gap: 2rem;
-          list-style-type: none;
-          margin: 0;
-          padding: 0;
-        }
-        & ul li {
-          width: 100%;
-          padding-bottom: var(--size-7);
-          border-bottom: 2px solid var(--surface-2);
-        }
-        & ul li:last-of-type {
-          border-bottom: 0;
-        }
-        & ul li * {
-          text-decoration: none;
-          transition: 0.2s ease;
-        }
-        & ul li a {
-          display: block;
-        }
-        & ul li a:hover h4,
-        & ul li a:hover .date {
-          color: rgb(var(--accent));
-        }
-        & ul a:hover img,
-        & ul a:hover .description {
-          box-shadow: var(--shadow-4);
-        }
-      }
-      .secondary {
-        & ul {
-          max-inline-size: var(--size-content-3);
-        }
-      }
-    </style>
+      </ul>
+
+      <div class="sec-head">
+        <h2>Off the clock</h2>
+        <span class="count">projects · &amp; · enjoying</span>
+      </div>
+
+      <div class="two">
+        <div class="card">
+          <h4><span class="dot" style="background:var(--gold)"></span>Recent Projects</h4>
+          <ul>
+            <li>
+              <a href="https://actual.ai">Actual AI</a>
+              <span class="meta">— Guardrails for AI-Powered Software Development.</span>
+            </li>
+            <li>
+              <span class="meta">Stealth Read Later App — Side project city. More to come soon.</span>
+            </li>
+            <li>
+              <a href="https://github.com/backlineint/brianperry.dev">brianperry.dev</a>
+              <span class="meta">— This site, rebuilt more times than is reasonable.</span>
+            </li>
+          </ul>
+        </div>
+        <div class="card">
+          <h4><span class="dot" style="background:var(--coral)"></span>Currently Enjoying</h4>
+          <ul>
+            <li>
+              <a href="/posts/2026/2026-oscars-films/">2026 Oscars Films</a>
+              <span class="meta">— unusually crowd-pleasing list this year.</span>
+            </li>
+            <li>
+              <a href="https://www.residentevil.com/requiem/en-us/">Resident Evil Requiem</a>
+              <span class="meta">— playing like a total wuss, saving every five seconds. Runs great on Switch 2.</span>
+            </li>
+            <li>
+              <a href="https://www.nintendo.com/us/store/products/pokemon-pokopia-switch-2">Pokopia</a>
+              <span class="meta">— scratching the Animal Crossing itch.</span>
+            </li>
+            <li>
+              <a href="https://www.youtube.com/playlist?list=PLcZMZxR9uxC8Wgves165_y4Kakqq5F5hZ">I Used to Go to This Bar — Joyce Manor</a>
+              <span class="meta">— perfect 19-minute punk album.</span>
+            </li>
+          </ul>
+        </div>
+      </div>
+    </main>
+
+    <Footer />
   </body>
 </html>

--- a/src/pages/posts/index.astro
+++ b/src/pages/posts/index.astro
@@ -13,85 +13,37 @@ const posts = await getSortedPosts();
 <!doctype html>
 <html lang="en">
   <head>
-    <BaseHead title={`Posts - ${SITE_TITLE}`} description={SITE_DESCRIPTION} />
-    <style>
-      main {
-        width: 1000px;
-      }
-      h1 {
-        margin: 0 0 var(--size-7) 0;
-      }
-      ul {
-        display: flex;
-        flex-wrap: wrap;
-        gap: 2rem;
-        list-style-type: none;
-        margin: 0;
-        padding: 0;
-      }
-      ul li {
-        width: 100%;
-        padding-bottom: var(--size-7);
-        border-bottom: 2px solid var(--surface-2);
-      }
-      ul li:last-of-type {
-        border-bottom: 0;
-      }
-      ul li * {
-        text-decoration: none;
-        transition: 0.2s ease;
-      }
-      ul li a {
-        display: block;
-      }
-      ul li a:hover h4,
-      ul li a:hover .date {
-        color: rgb(var(--accent));
-      }
-      ul a:hover img,
-      ul a:hover .description {
-        box-shadow: var(--shadow-4);
-      }
-      /* Open Props Tweaks */
-      :where(h4, p, li) {
-        max-inline-size: none;
-      }
-      :where(li, p) {
-        padding-inline-start: 0;
-      }
-      @media (max-width: 720px) {
-        ul {
-          gap: 0.5em;
-        }
-        ul li {
-          width: 100%;
-          margin-top: var(--size-6);
-        }
-        ul li:first-child {
-          margin-bottom: 0;
-        }
-        ul li:first-child .title {
-          font-size: 1.563em;
-        }
-      }
-    </style>
+    <BaseHead title={`Writing - ${SITE_TITLE}`} description={SITE_DESCRIPTION} />
   </head>
   <body>
     <Header />
-    <main>
-      <section>
-        <h1>Posts</h1>
-        <ul>
-          {
-            posts.map((post) => (
-              <li>
-                <RadPostTeaser post={post} />
-              </li>
-            ))
-          }
-        </ul>
-      </section>
+
+    <svg class="rings" width="1100" height="700" style="top:30px" viewBox="0 0 1100 700" aria-hidden="true">
+      <circle cx="550" cy="120" r="180"></circle><circle cx="550" cy="120" r="300"></circle><circle cx="550" cy="120" r="430"></circle>
+    </svg>
+
+    <header class="hero wrap" style="padding-bottom:0">
+      <h1 class="mast" style="font-size:clamp(48px,8vw,72px)">Writing</h1>
+      <p class="tag">notes on code, drupal, ai &amp; the occasional record review</p>
+    </header>
+
+    <main class="wrap">
+      <div class="sec-head" style="margin-top:46px">
+        <h2 style="font-size:22px">All posts</h2>
+        <span class="count">archive · {posts.length} entries</span>
+      </div>
+
+      <ul class="rows">
+        {
+          posts.map((post) => (
+            <li>
+              <RadPostTeaser post={post} />
+            </li>
+          ))
+        }
+      </ul>
     </main>
+
     <Footer />
   </body>
 </html>

--- a/src/styles/broadcast.css
+++ b/src/styles/broadcast.css
@@ -1,0 +1,320 @@
+/* ============================================================
+   CONCEPT A — "BROADCAST"
+   Dark indigo · chunky slab masthead · radiating rings + clouds
+   coral mono kickers · electric blue + gold accents
+
+   Adapted from the Claude Design handoff (concepts/a.css) into the
+   live Astro site. The mockup was a fixed 1280px artboard; here the
+   layout is fluid and the big display type scales with clamp().
+   ============================================================ */
+
+:root {
+  --bg:        #0c1024;
+  --bg-2:      #0a0e1f;
+  --surface:   #141a3a;
+  --surface-2: #1a2249;
+  --ink:       #f3f1e9;
+  --muted:     #9aa3cf;
+  --faint:     #6b73a0;
+  --blue:      #6aa0ff;
+  --blue-deep: #3f6fe0;
+  --gold:      #f4b740;
+  --coral:     #ff6f5e;
+  --line:      rgba(255, 255, 255, 0.10);
+  --line-soft: rgba(255, 255, 255, 0.06);
+
+  /* Map the Open Props normalize theme vars onto the Broadcast palette so
+     existing components (Footer, teasers, prose) inherit the dark indigo
+     look automatically. These are declared last in the cascade (broadcast.css
+     is imported after normalize), so they win over its light/dark defaults. */
+  color-scheme: dark;
+  --text-1: var(--ink);
+  --text-2: var(--muted);
+  --surface-1: var(--bg);
+  --surface-3: var(--surface-2);
+  --surface-4: #222c5e;
+  --link: var(--blue);
+  --link-visited: var(--blue);
+  --accent: 106, 160, 255;
+  --box-shadow: 0 18px 40px rgba(0, 0, 0, 0.45);
+}
+
+* { box-sizing: border-box; }
+
+html { background: var(--bg); }
+html, body { margin: 0; padding: 0; }
+
+body {
+  background:
+    radial-gradient(120% 80% at 50% -10%, #1a2150 0%, rgba(26, 33, 80, 0) 55%),
+    linear-gradient(180deg, var(--bg) 0%, var(--bg-2) 100%);
+  background-attachment: fixed;
+  color: var(--ink);
+  font-family: "Libre Franklin", system-ui, sans-serif;
+  font-size: 18px;
+  line-height: 1.6;
+  -webkit-font-smoothing: antialiased;
+}
+
+a { color: inherit; text-decoration: none; }
+
+.slab { font-family: "Alfa Slab One", Georgia, serif; font-weight: 400; }
+.mono { font-family: "Space Mono", ui-monospace, monospace; }
+
+/* ---- shell ---- */
+.wrap {
+  width: 100%;
+  max-width: 1040px;
+  margin: 0 auto;
+  padding: 0 48px;
+}
+
+/* ---- top nav ---- */
+.nav {
+  display: flex; align-items: center; justify-content: space-between;
+  gap: 18px;
+  padding: 26px 48px;
+  max-width: 1040px; margin: 0 auto;
+  position: relative; z-index: 3;
+}
+.nav .brand {
+  font-family: "Space Mono", monospace;
+  font-weight: 700; font-size: 16px; letter-spacing: 0.02em;
+  color: var(--ink);
+}
+.nav .brand b { color: var(--blue); }
+.nav .links { display: flex; align-items: center; gap: 28px; }
+.nav .links a {
+  font-family: "Space Mono", monospace;
+  font-size: 13px; letter-spacing: 0.14em; text-transform: uppercase;
+  color: var(--muted); padding-bottom: 3px;
+  border-bottom: 2px solid transparent;
+  transition: color .15s, border-color .15s;
+}
+.nav .links a:hover { color: var(--ink); }
+.nav .links a.active { color: var(--gold); border-color: var(--gold); }
+.nav .ico { display: flex; gap: 14px; align-items: center; }
+.nav .ico a { display: flex; color: var(--muted); transition: color .15s; }
+.nav .ico a:hover { color: var(--ink); }
+.nav .ico svg { width: 20px; height: 20px; fill: currentColor; }
+
+/* ---- decorative rings ---- */
+.rings { position: absolute; left: 50%; transform: translateX(-50%); pointer-events: none; z-index: 0; max-width: 100%; }
+.rings circle { fill: none; stroke: var(--line-soft); }
+
+/* ---- pill badge ---- */
+.pill {
+  display: inline-flex; align-items: center; gap: 7px;
+  font-family: "Space Mono", monospace; font-weight: 700;
+  font-size: 11px; letter-spacing: 0.18em; text-transform: uppercase;
+  color: var(--bg); background: var(--gold);
+  padding: 5px 11px; border-radius: 999px;
+}
+.pill.ghost { color: var(--gold); background: transparent; border: 1px solid var(--gold); }
+
+/* ---- mono kicker ---- */
+.kicker {
+  font-family: "Space Mono", monospace;
+  font-size: 12.5px; letter-spacing: 0.16em; text-transform: uppercase;
+  color: var(--coral); display: flex; align-items: center; gap: 12px;
+  flex-wrap: wrap;
+}
+.kicker .num {
+  border: 1px solid var(--coral); border-radius: 5px;
+  padding: 2px 7px; color: var(--coral); letter-spacing: 0.1em;
+}
+.kicker time { color: inherit; }
+
+/* ---- hero ---- */
+.hero { position: relative; text-align: center; padding: 30px 0 12px; }
+.hero h1.mast {
+  font-family: "Alfa Slab One", Georgia, serif; font-weight: 400;
+  font-size: clamp(40px, 10.5vw, 92px); line-height: 0.92; letter-spacing: -0.01em;
+  margin: 14px 0 0; text-transform: uppercase;
+  text-shadow: 0 3px 0 rgba(0, 0, 0, 0.25);
+}
+.hero h1.mast .l2 { color: var(--blue); display: block; }
+.hero .tag {
+  font-family: "Space Mono", monospace; font-size: 15px;
+  letter-spacing: 0.04em; color: var(--gold); margin-top: 18px;
+}
+.hero .bio {
+  max-width: 600px; margin: 22px auto 0; color: var(--muted);
+  font-size: 18px; line-height: 1.65; text-wrap: pretty;
+}
+.hero .bio a { color: var(--blue); border-bottom: 1px solid rgba(106, 160, 255, 0.4); }
+
+/* ---- find-me button row ---- */
+.findme {
+  display: flex; flex-wrap: wrap; gap: 12px; justify-content: center;
+  margin: 30px auto 0; padding: 0; list-style: none;
+}
+.findme a {
+  display: inline-flex; align-items: center; gap: 9px;
+  background: var(--surface); border: 1px solid var(--line);
+  border-radius: 12px; padding: 11px 16px;
+  font-size: 14.5px; font-weight: 600; color: var(--ink);
+  transition: background .15s, border-color .15s, transform .15s;
+}
+.findme a:hover { background: var(--surface-2); border-color: var(--blue); transform: translateY(-2px); }
+.findme a svg { width: 17px; height: 17px; color: var(--blue); fill: currentColor; flex: none; }
+
+/* ---- section heading ---- */
+.sec-head {
+  display: flex; align-items: baseline; justify-content: space-between;
+  gap: 16px; flex-wrap: wrap;
+  border-bottom: 1px solid var(--line); padding-bottom: 14px; margin: 56px 0 30px;
+}
+.sec-head h2 {
+  font-family: "Alfa Slab One", Georgia, serif; font-weight: 400; font-size: 30px; margin: 0;
+  letter-spacing: 0.01em; color: var(--ink);
+}
+.sec-head .count {
+  font-family: "Space Mono", monospace; font-size: 12.5px;
+  letter-spacing: 0.16em; text-transform: uppercase; color: var(--faint);
+}
+
+/* ---- post rows (feed) ---- */
+.rows { display: flex; flex-direction: column; list-style: none; margin: 0; padding: 0; }
+.rows > li { margin: 0; padding: 0; max-inline-size: none; }
+.row {
+  display: grid; grid-template-columns: 1fr 168px; gap: 36px;
+  align-items: center; padding: 30px 0;
+  border-bottom: 1px solid var(--line-soft);
+}
+.row.noimg { grid-template-columns: 1fr; }
+.row .rk { margin-bottom: 12px; }
+.row h3 {
+  font-family: "Alfa Slab One", Georgia, serif; font-weight: 400;
+  font-size: 30px; line-height: 1.12; margin: 0 0 10px;
+  letter-spacing: -0.005em;
+}
+.row h3 a { transition: color .15s; }
+.row:hover h3 a { color: var(--blue); }
+.row h3 .arr { color: var(--gold); margin-left: 8px; }
+.row p { margin: 0; color: var(--muted); font-size: 16.5px; max-width: 60ch; }
+.row .tags { margin-top: 14px; display: flex; gap: 8px; flex-wrap: wrap; }
+.tag {
+  font-family: "Space Mono", monospace; font-size: 11px;
+  letter-spacing: 0.1em; text-transform: uppercase; color: var(--faint);
+  border: 1px solid var(--line); border-radius: 5px; padding: 3px 8px;
+}
+
+/* ---- thumbnail (duotone placeholder or real image) ---- */
+.thumb {
+  position: relative; border-radius: 12px; overflow: hidden;
+  aspect-ratio: 16 / 11; border: 1px solid var(--line);
+}
+.thumb.sq { aspect-ratio: 1 / 1; }
+.thumb img { display: block; width: 100%; height: 100%; object-fit: cover; border-radius: 0; box-shadow: none; margin: 0; }
+.thumb .lbl {
+  position: absolute; left: 10px; bottom: 9px;
+  font-family: "Space Mono", monospace; font-size: 10px;
+  letter-spacing: 0.12em; text-transform: uppercase; color: rgba(255, 255, 255, 0.7);
+}
+.duo-1 { background: linear-gradient(135deg, #3f6fe0, #ff6f5e); }
+.duo-2 { background: linear-gradient(135deg, #1a2249, #6aa0ff); }
+.duo-3 { background: linear-gradient(135deg, #f4b740, #ff6f5e); }
+.duo-4 { background: linear-gradient(135deg, #2a3170, #9aa3cf); }
+.duo-5 { background: linear-gradient(135deg, #ff6f5e, #f4b740); }
+.duo-6 { background: linear-gradient(135deg, #3f6fe0, #1a2249); }
+
+/* ---- two-up cards (projects / enjoying) ---- */
+.two { display: grid; grid-template-columns: 1fr 1fr; gap: 24px; }
+.card {
+  background: var(--surface); border: 1px solid var(--line);
+  border-radius: 16px; padding: 26px 28px;
+}
+.card h4 {
+  font-family: "Alfa Slab One", Georgia, serif; font-weight: 400; font-size: 20px;
+  margin: 0 0 18px; display: flex; align-items: center; gap: 10px; color: var(--ink);
+}
+.card h4 .dot { width: 9px; height: 9px; border-radius: 3px; flex: none; }
+.card ul { list-style: none; margin: 0; padding: 0; }
+.card li { padding: 13px 0; border-top: 1px solid var(--line-soft); font-size: 16px; line-height: 1.5; max-inline-size: none; }
+.card li:first-child { border-top: none; padding-top: 0; }
+.card li a { color: var(--blue); font-weight: 600; }
+.card li .meta { color: var(--muted); }
+
+/* ---- article (single post) ---- */
+.article { width: 100%; max-width: 720px; margin: 0 auto; padding: 0 24px; }
+.article .backlink { font-family: "Space Mono", monospace; color: var(--faint); font-size: 13px; letter-spacing: 0.1em; }
+.article .post-hero {
+  border-radius: 16px; overflow: hidden; aspect-ratio: 16/8;
+  margin: 18px 0 0; position: relative; border: 1px solid var(--line);
+}
+.article .post-hero img { display: block; width: 100%; height: 100%; object-fit: cover; border-radius: 0; box-shadow: none; margin: 0; }
+.article h1.title {
+  font-family: "Alfa Slab One", Georgia, serif; font-weight: 400;
+  font-size: clamp(38px, 7vw, 56px); line-height: 1.02; letter-spacing: -0.01em;
+  margin: 26px 0 0; text-align: center;
+}
+.article h1.title em { color: var(--blue); font-style: normal; }
+.article .post-meta { text-align: center; margin: 26px 0 0; justify-content: center; }
+.article .rule { height: 1px; background: var(--line); margin: 30px 0; border: 0; }
+
+/* article body / prose */
+.article .body, .prose {
+  font-size: 18.5px; line-height: 1.72; color: #e7e5db;
+}
+.article .body p, .prose p { margin: 0 0 24px; }
+.article .body a, .prose a { color: var(--blue); border-bottom: 1px solid rgba(106, 160, 255, 0.4); text-decoration: none; }
+.article .body h2, .prose h2,
+.article .body h3, .prose h3,
+.article .body h4, .prose h4,
+.article .body h5, .prose h5,
+.article .body h6, .prose h6 {
+  font-family: "Alfa Slab One", Georgia, serif; font-weight: 400;
+  color: var(--gold); line-height: 1.15;
+}
+.article .body h2, .prose h2 { font-size: 28px; margin: 48px 0 16px; }
+.article .body h3, .prose h3 { font-size: 24px; margin: 42px 0 14px; }
+.article .body h4, .prose h4 { font-size: 20px; margin: 36px 0 12px; }
+.article .body h5, .prose h5,
+.article .body h6, .prose h6 {
+  font-family: "Space Mono", monospace; color: var(--coral);
+  font-size: 13px; letter-spacing: 0.14em; text-transform: uppercase; margin: 30px 0 10px;
+}
+.prose img { border-radius: 12px; }
+.article .body ul, .prose ul { padding-left: 0; list-style: none; }
+.article .body ul li, .prose ul li {
+  position: relative; padding: 10px 0 10px 26px; border-bottom: 1px solid var(--line-soft);
+  max-inline-size: none;
+}
+.article .body ul li::before, .prose ul li::before {
+  content: "\25B8"; position: absolute; left: 0; color: var(--coral);
+}
+.prose ol { padding-left: 1.4em; }
+.prose blockquote { border-left: 4px solid var(--coral); color: var(--muted); }
+.prose pre { background: var(--bg-2); border: 1px solid var(--line); }
+.prose :not(pre) > code { background: var(--surface); color: var(--gold); }
+
+/* ---- footer w/ clouds ---- */
+.foot { position: relative; margin-top: 80px; padding-top: 90px; background: transparent; color: var(--muted); text-align: center; }
+.clouds { position: absolute; left: 0; right: 0; bottom: 100%; width: 100%; display: block; }
+.foot-inner {
+  background: var(--bg-2); border-top: 1px solid var(--line);
+  text-align: center; padding: 44px 0 56px;
+}
+.foot .made { font-size: 16px; color: var(--muted); }
+.foot .made b { color: var(--ink); font-weight: 700; }
+.foot .social { display: flex; gap: 20px; justify-content: center; margin: 22px 0 18px; }
+.foot .social a { display: flex; color: var(--muted); transition: color .15s; }
+.foot .social svg { width: 22px; height: 22px; fill: currentColor; }
+.foot .social a:hover { color: var(--gold); }
+.foot .botlinks { font-family: "Space Mono", monospace; font-size: 13px; letter-spacing: 0.1em; color: var(--faint); }
+.foot .botlinks a { color: var(--blue); }
+.foot .botlinks span { margin: 0 10px; opacity: 0.5; }
+
+/* ---- responsive ---- */
+@media (max-width: 860px) {
+  .two { grid-template-columns: 1fr; }
+}
+@media (max-width: 680px) {
+  .nav { flex-wrap: wrap; padding: 20px 24px; gap: 12px; }
+  .nav .links { gap: 18px; }
+  .wrap { padding: 0 24px; }
+  .row { grid-template-columns: 1fr; gap: 18px; }
+  .row .thumb { order: -1; }
+  .sec-head h2 { font-size: 24px; }
+}


### PR DESCRIPTION
## What

Applies **Concept A — "Broadcast"** from the Claude Design handoff to the entire site: a dark-indigo editorial look with a chunky **Alfa Slab One** masthead, radiating ring + horizon-cloud motifs, **Space Mono** coral kickers, and electric-blue + gold accents — itshipped.fm's energy in Brian's blue.

## Why

This is the implementation of the redesign direction explored in the design tool. The handoff shipped fixed-width HTML/CSS mockups (Home / Writing feed / Single post); this PR recreates that visual language as real, responsive Astro components.

## Changes

- **`src/styles/broadcast.css`** (new) — the full design system, ported from the concept's `a.css`. Uses `clamp()` for display type instead of the mockup's fixed 1280px artboard, and maps the Open Props theme vars (`--text-*`, `--surface-*`, `--link`) onto the Broadcast palette so existing components inherit the dark theme.
- **`BaseHead.astro`** — loads the Google Fonts trio (Alfa Slab One / Libre Franklin / Space Mono), drops the Atkinson preloads, imports the new stylesheet last.
- **`Header.astro` / `Footer.astro`** — mono brand + uppercase nav with a gold active state; footer gains the horizon-cloud SVG and social/bottom links.
- **`index.astro`** — rings, gold pill, stacked masthead, mono bio, find-me row, **Latest** rows, and the **Off the clock** two-up cards (Recent Projects / Currently Enjoying).
- **`posts/index.astro` + `RadPostTeaser.astro`** — the Writing feed with a section header + archive count, and post rows with coral date kickers, slab titles, tags, and real thumbnails when a post has an image.
- **`Post.astro` / `MarkdownPage.astro`** — article layout: back link, centered slab title, kicker meta, 16:8 hero, rule, and prose body styled with gold slab headings, blue links, and coral `▸` bullets.

## Reviewer notes

- The site's content uses `##`/`###`/`####` for section headings (the mockup only had one level), so prose `h2–h4` get a descending gold slab scale and `h5/h6` become coral mono — a deliberate extension beyond the single mockup style to fit real posts.
- The home photo (`perry_weather.jpg`) isn't part of the Broadcast design, so it was dropped from the home page; the asset and the now-unused `RadTwoCol` component remain in the repo.

## Verification

- Checked Home, Writing feed (two-column rows w/ thumbnails), a single post, and the About markdown page — no console errors, no horizontal overflow, layout centered.
- Verified mobile (375px): nav wraps, masthead scales without clipping, rows stack.
- `pnpm build` passes `astro check` and builds all 64 pages.

🤖 Generated with [Claude Code](https://claude.com/claude-code)