### PR TITLE
Center blockquote & callout text, unconstrain blockquote width

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,3 +1,7 @@
+# Development Notes
+
+- **CSS changes to `src/styles/global.css` may not hot-reload.** The Astro dev server's file watcher sometimes doesn't pick up edits to `src/styles/global.css` mid-session — reloading the page keeps showing the old styles. If a CSS change isn't taking effect, restart the dev/preview server for a clean build rather than assuming the edit is wrong. (`global.css` is imported once in `src/components/BaseHead.astro`.)
+
 # Writing Style Guide for brianperry.dev
 
 When drafting or revising blog posts for this site, follow these guidelines to match Brian's voice.

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -421,14 +421,23 @@ img {
 	border-left: 4px solid var(--gold);
 	background: var(--surface);
 	border-radius: 0 14px 14px 0;
-	padding: 2px 22px;
+	padding: 16px 22px;
 	margin: 0 0 22px;
 	color: var(--ink);
 	font-size: 1.15em;
+	max-inline-size: none;
 }
 
-.prose :where(blockquote p) {
+.prose blockquote p {
 	font-size: inherit;
+	margin: 0;
+	max-inline-size: none;
+}
+
+/* Drop the trailing prose margin on a callout's last paragraph so its text
+   sits centered within the padded box instead of riding high. */
+.prose rad-callout p:last-child {
+	margin-bottom: 0;
 }
 
 .prose code {


### PR DESCRIPTION
## What changed

Fixes vertical alignment of text inside the **blockquote** and **RadCallout** on the About page, and removes the width cap on blockquotes.

- **Vertical centering** — The inner `<p>` of both elements inherited `.prose p { margin: 0 0 22px }`, adding a phantom 22px below the text that pushed it toward the top of its box. The existing blockquote override used `.prose :where(blockquote p)`, but `:where()` zeroes specificity so `.prose p` silently won. Raised specificity (`.prose blockquote p`) and zeroed the margin; added a matching `.prose rad-callout p:last-child { margin-bottom: 0 }` rule for the callout. Bumped blockquote vertical padding from `2px` to `16px` so the centered text has comfortable breathing room.
- **Width** — Removed Open Props' `max-inline-size` cap on `.prose blockquote` and its paragraph so blockquotes fill the prose width like other content, matching the pattern already used for headings and list items.
- **Docs** — Added a Development Notes section to `AGENTS.md` documenting that `src/styles/global.css` edits don't reliably hot-reload mid-session (restart the dev/preview server).

## Why

The callout and blockquote looked top-heavy — text hugging the top edge with a gap below — rather than centered within their padded boxes.

## Verification

Verified in the browser preview on `/about`: both elements now report equal space above and below their text (blockquote 16px/16px, callout 32px/32px) with the paragraph bottom margin at `0`. The `:last-child` selector on the callout rule preserves spacing if a callout ever holds multiple paragraphs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)