### PR TITLE
Refresh Currently Enjoying list

### DIFF
--- a/.claude/launch.json
+++ b/.claude/launch.json
@@ -5,7 +5,8 @@
       "name": "dev",
       "runtimeExecutable": "pnpm",
       "runtimeArgs": ["dev"],
-      "port": 4321
+      "port": 4321,
+      "autoPort": true
     }
   ]
 }

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -123,20 +123,16 @@ const duos = [1, 3, 2, 4, 6, 5];
           <h4><span class="badge green tag">1-UP</span>Currently Enjoying</h4>
           <ul>
             <li>
-              <span class="ic" style="background:var(--green)"></span>
-              <span><a href="https://www.residentevil.com/requiem/en-us/">Resident Evil Requiem</a> <span class="m">— playing like a total wuss. Runs great on Switch 2.</span></span>
+              <span class="ic" style="background:var(--gold)"></span>
+              <span><a href="https://www.imdb.com/title/tt33332385/">Widows Bay</a> <span class="m">— quirky horror-comedy series and proof that all of New England is haunted.</span></span>
             </li>
             <li>
               <span class="ic" style="background:var(--cyan)"></span>
-              <span><a href="https://www.nintendo.com/us/store/products/pokemon-pokopia-switch-2">Pokopia</a> <span class="m">— scratching the Animal Crossing itch.</span></span>
-            </li>
-            <li>
-              <span class="ic" style="background:var(--gold)"></span>
-              <span><a href="/posts/2026/2026-oscars-films/">2026 Oscars Films</a> <span class="m">— unusually crowd-pleasing this year.</span></span>
+              <span><a href="https://www.yachtclubgames.com/games/mina-the-hollower/">Mina the Hollower</a> <span class="m">— a take on Game Boy Color era Zelda from the Shovel Knight team.</span></span>
             </li>
             <li>
               <span class="ic" style="background:var(--red)"></span>
-              <span><a href="https://www.youtube.com/playlist?list=PLcZMZxR9uxC8Wgves165_y4Kakqq5F5hZ">Joyce Manor</a> <span class="m">— perfect 19-minute punk album.</span></span>
+              <span><a href="https://open.spotify.com/album/4I3Ea3ZOeHI9lmKd2Pyact">The Obsessives</a> <span class="m">— keep coming back to this indie rock album that randomly came up in my autoplay.</span></span>
             </li>
           </ul>
         </div>


### PR DESCRIPTION
## What changed

Updated the **Currently Enjoying** section on the home page ([src/pages/index.astro](src/pages/index.astro)):

- Removed the older entries: Resident Evil Requiem, Pokopia, 2026 Oscars Films, and Joyce Manor.
- Added three new picks:
  - **Widows Bay** — quirky horror-comedy series and proof that all of New England is haunted ([IMDb](https://www.imdb.com/title/tt33332385/))
  - **Mina the Hollower** — a take on Game Boy Color era Zelda from the Shovel Knight team ([Yacht Club Games](https://www.yachtclubgames.com/games/mina-the-hollower/))
  - **The Obsessives** — indie rock album that randomly came up in autoplay ([Spotify](https://open.spotify.com/album/4I3Ea3ZOeHI9lmKd2Pyact))

## Also

- Added `"autoPort": true` to `.claude/launch.json` so the preview dev server falls back to a free port when 4321 is already in use.

## Notes for reviewer

- Content-only change to the home page plus a dev-tooling tweak; verified rendering locally in the preview server.

🤖 Generated with [Claude Code](https://claude.com/claude-code)