### PR TITLE
Add homepage-style footer

### DIFF
--- a/src/components/Footer.astro
+++ b/src/components/Footer.astro
@@ -1,4 +1,85 @@
-<footer class="foot">
+---
+import { Image } from "astro:assets";
+import { getSortedPosts } from "../lib/getSortedPosts";
+import ButtonCluster from "./ButtonCluster.astro";
+import StickerCard from "./StickerCard.astro";
+import portrait from "../assets/perry_weather.jpg";
+
+const allPosts = await getSortedPosts();
+const latest = allPosts.slice(0, 3);
+const duos = [4, 6, 5];
+const isHome = Astro.url.pathname === "/";
+---
+
+<footer class:list={["foot", { "home-foot": !isHome }]}>
+  {
+    !isHome && (
+      <section class="home-footer" aria-labelledby="home-footer-title">
+        <div class="home-footer-kicker">
+          <span>// you made it to the bottom</span>
+          <ButtonCluster />
+        </div>
+
+        <div class="home-footer-hero">
+          <div class="home-footer-copy">
+            <p class="eyebrow">The footer is the homepage now</p>
+            <h2 id="home-footer-title">
+              Brian <span>Perry</span>.dev
+            </h2>
+            <p>
+              I'm a <a href="https://github.com/backlineint">web developer</a> figuring out
+              what AI agents are actually good for at <a href="https://actual.ai">Actual AI</a>,
+              a longtime <a href="https://www.drupal.org/u/brianperry">Drupal person</a>,
+              occasional <a href="https://noti.st/brianperry">conference speaker</a>,
+              Chicago suburbs dad, and Nintendo enjoyer. Basically the whole homepage, but hiding
+              in the footer like a raccoon with a LinkedIn profile.
+            </p>
+            <div class="footer-actions">
+              <a href="/">Home base</a>
+              <a href="/about">About</a>
+              <a href="/posts">All posts</a>
+              <a href="/feed.xml">RSS</a>
+            </div>
+          </div>
+
+          <a class="portrait-card" href="/about" aria-label="About Brian Perry">
+            <Image
+              src={portrait}
+              alt="Brian with a weather station"
+              width={360}
+              height={402}
+            />
+            <span>// brian</span>
+          </a>
+        </div>
+
+        <div class="home-footer-grid">
+          <section class="latest-block" aria-labelledby="home-footer-latest">
+            <div class="section-head">
+              <h3 id="home-footer-latest">Latest</h3>
+              <span></span>
+            </div>
+            <div class="mini-mosaic">
+              {latest.map((post, i) => <StickerCard post={post} duo={duos[i % duos.length]} />)}
+            </div>
+          </section>
+
+          <section class="play-block" aria-labelledby="home-footer-play">
+            <div class="section-head">
+              <h3 id="home-footer-play">Work &amp; Play</h3>
+              <span></span>
+            </div>
+            <div class="panel-list">
+              <a href="https://actual.ai"><b>Actual AI</b><small>Guardrails for AI-powered software development.</small></a>
+              <a href="https://github.com/backlineint/brianperry.dev"><b>brianperry.dev</b><small>Rebuilt more times than is reasonable.</small></a>
+              <a href="https://www.yachtclubgames.com/games/mina-the-hollower/"><b>Mina the Hollower</b><small>Game Boy Color Zelda energy from the Shovel Knight team.</small></a>
+            </div>
+          </section>
+        </div>
+      </section>
+    )
+  }
+
   <div class="foot-inner">
     <div class="made">Made with 🥯 by <b>Brian Perry</b>.</div>
     <div class="social">
@@ -11,75 +92,44 @@
         <svg viewBox="0 0 16 16" aria-hidden="true"><path fill="currentColor" d="M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82.64-.18 1.32-.27 2-.27.68 0 1.36.09 2 .27 1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55.38A8.012 8.012 0 0 0 16 8c0-4.42-3.58-8-8-8z"></path></svg>
       </a>
     </div>
-    <div class="botlinks">
-      <a href="/feed.xml">Feed</a><span>·</span><a href="/style-guide">Style Guide</a>
-    </div>
+    <div class="botlinks"><a href="/feed.xml">Feed</a><span>·</span><a href="/style-guide">Style Guide</a></div>
   </div>
 </footer>
 <style>
-  .foot {
-    margin-top: var(--footer-gap, 76px);
-    border-top: 2px solid var(--line);
-    background: var(--bg-2);
-  }
-  .foot-inner {
-    max-width: 1080px;
-    margin: 0 auto;
-    padding: 42px 24px 50px;
-    text-align: center;
-  }
-  .made {
-    font-size: 16px;
-    color: var(--muted);
-  }
-  .made b {
-    color: var(--ink);
-    font-weight: 700;
-  }
-  .social {
-    display: flex;
-    gap: 14px;
-    justify-content: center;
-    margin: 20px 0 16px;
-  }
-  .social a {
-    width: 38px;
-    height: 38px;
-    border-radius: 10px;
-    background: var(--surface);
-    margin: 0;
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    transition: background 0.15s;
-  }
-  .social a:hover {
-    background: var(--surface-2);
-  }
-  .social svg {
-    width: 19px;
-    height: 19px;
-    fill: var(--muted);
-    color: var(--muted);
-    transition: fill 0.15s, color 0.15s;
-  }
-  .social a:hover svg {
-    fill: var(--gold);
-    color: var(--gold);
-  }
-  .botlinks {
-    font-family: "JetBrains Mono", monospace;
-    font-size: 12px;
-    letter-spacing: 0.1em;
-    text-transform: uppercase;
-    color: var(--faint);
-  }
-  .botlinks a {
-    color: var(--cyan);
-    text-decoration: none;
-  }
-  .botlinks span {
-    margin: 0 9px;
-    opacity: 0.5;
-  }
+  .foot { margin-top: var(--footer-gap, 76px); border-top: 2px solid var(--line); background: var(--bg-2); }
+  .home-foot { border-top: 0; background: linear-gradient(180deg, transparent, var(--bg-2) 14%); }
+  .home-footer { width: min(1080px, 100%); margin: 0 auto; padding: 64px var(--page-gutter) 30px; }
+  .home-footer-kicker, .section-head { display: flex; align-items: center; gap: 14px; margin-bottom: 22px; font-family: var(--font-mono); font-size: 12px; letter-spacing: .12em; text-transform: uppercase; color: var(--cyan); }
+  .home-footer-hero { display: grid; grid-template-columns: minmax(0, 1fr) 210px; gap: 36px; align-items: center; padding: 30px; border: 2px solid var(--line); border-radius: 24px; background: color-mix(in srgb, var(--surface) 78%, transparent); box-shadow: var(--box-shadow); }
+  .eyebrow { margin: 0 0 10px; font-family: var(--font-mono); font-size: 12px; letter-spacing: .16em; text-transform: uppercase; color: var(--gold); }
+  h2 { font-size: clamp(40px, 6vw, 72px); line-height: .9; text-transform: uppercase; margin: 0; }
+  h2 span { color: var(--red); }
+  .home-footer-copy > p:not(.eyebrow) { max-width: 670px; color: var(--muted); font-size: 18px; }
+  .footer-actions { display: flex; flex-wrap: wrap; gap: 10px; margin-top: 22px; }
+  .footer-actions a, .panel-list a { border: 2px solid var(--line); border-radius: 12px; background: var(--surface); color: var(--ink); text-decoration: none; transition: transform .12s, border-color .12s; }
+  .footer-actions a { padding: 9px 14px; font-family: var(--font-mono); font-size: 12px; font-weight: 700; letter-spacing: .08em; text-transform: uppercase; }
+  .footer-actions a:hover, .panel-list a:hover { transform: translate(-1px, -1px); border-color: var(--cyan); }
+  .portrait-card { position: relative; display: block; transform: rotate(3deg); color: var(--badge-ink); text-decoration: none; }
+  .portrait-card :global(img) { display: block; border: 6px solid var(--surface); border-radius: 18px; box-shadow: 7px 7px 0 var(--duo-frame-shadow); }
+  .portrait-card span { position: absolute; left: 50%; bottom: 13px; transform: translateX(-50%); padding: 4px 10px; border-radius: 7px; background: var(--gold); font-family: var(--font-mono); font-size: 11px; font-weight: 700; letter-spacing: .1em; }
+  .home-footer-grid { display: grid; grid-template-columns: minmax(0, 2fr) minmax(260px, 1fr); gap: 28px; margin-top: 38px; }
+  .section-head h3 { margin: 0; font-size: 22px; color: var(--ink); }
+  .section-head span { flex: 1; height: 2px; background: var(--line); }
+  .mini-mosaic { display: grid; grid-template-columns: repeat(3, minmax(0, 1fr)); gap: 18px; }
+  .panel-list { display: grid; gap: 14px; }
+  .panel-list a { display: grid; gap: 4px; padding: 18px; }
+  .panel-list b { color: var(--gold); }
+  .panel-list small { color: var(--muted); line-height: 1.4; }
+  .foot-inner { max-width: 1080px; margin: 0 auto; padding: 42px 24px 50px; text-align: center; }
+  .made { font-size: 16px; color: var(--muted); }
+  .made b { color: var(--ink); font-weight: 700; }
+  .social { display: flex; gap: 14px; justify-content: center; margin: 20px 0 16px; }
+  .social a { width: 38px; height: 38px; border-radius: 10px; background: var(--surface); margin: 0; display: flex; align-items: center; justify-content: center; transition: background 0.15s; }
+  .social a:hover { background: var(--surface-2); }
+  .social svg { width: 19px; height: 19px; fill: var(--muted); color: var(--muted); transition: fill 0.15s, color 0.15s; }
+  .social a:hover svg { fill: var(--gold); color: var(--gold); }
+  .botlinks { font-family: "JetBrains Mono", monospace; font-size: 12px; letter-spacing: 0.1em; text-transform: uppercase; color: var(--faint); }
+  .botlinks a { color: var(--cyan); text-decoration: none; }
+  .botlinks span { margin: 0 9px; opacity: 0.5; }
+  @media (max-width: 900px) { .home-footer-hero, .home-footer-grid { grid-template-columns: 1fr; } .portrait-card { max-width: 220px; justify-self: center; } .mini-mosaic { grid-template-columns: 1fr; } }
 </style>

--- a/src/components/Footer.astro
+++ b/src/components/Footer.astro
@@ -2,7 +2,7 @@
 import { Image } from "astro:assets";
 import { getSortedPosts } from "../lib/getSortedPosts";
 import ButtonCluster from "./ButtonCluster.astro";
-import StickerCard from "./StickerCard.astro";
+import Cartridge from "./Cartridge.astro";
 import portrait from "../assets/perry_weather.jpg";
 
 const allPosts = await getSortedPosts();
@@ -10,7 +10,6 @@ const currentPath = Astro.url.pathname.replace(/\/$/, "");
 const latest = allPosts
   .filter((post) => `/${post.collection}/${post.slug}` !== currentPath)
   .slice(0, 3);
-const duos = [4, 6, 5];
 const isHome = Astro.url.pathname === "/";
 ---
 
@@ -73,8 +72,8 @@ const isHome = Astro.url.pathname === "/";
               <span class="line"></span>
               <ButtonCluster />
             </div>
-            <div class="mini-mosaic">
-              {latest.map((post, i) => <StickerCard post={post} duo={duos[i % duos.length]} />)}
+            <div class="footer-cart-list">
+              {latest.map((post) => <Cartridge post={post} />)}
             </div>
             <div class="see-all-row">
               <a class="see-all" href="/posts">All posts <span aria-hidden="true">→</span></a>
@@ -177,7 +176,7 @@ const isHome = Astro.url.pathname === "/";
   .frame.duo .starbadge path { fill: var(--gold); stroke: var(--surface); stroke-width: 1.2; }
   .home-footer-grid { display: grid; gap: 18px; margin-top: 0; }
   .home-footer-grid .sec-head { margin-top: 34px; }
-  .mini-mosaic { display: grid; grid-template-columns: repeat(3, minmax(0, 1fr)); gap: 18px; }
+  .footer-cart-list { display: grid; gap: 14px; }
   .see-all-row { display: flex; justify-content: flex-end; margin-top: 22px; }
   .see-all { display: inline-flex; align-items: center; gap: 8px; margin: 0; font-family: "JetBrains Mono", monospace; font-size: 12px; font-weight: 700; letter-spacing: 0.08em; text-transform: uppercase; color: var(--cyan); text-decoration: none; padding: 9px 15px; border: 2px solid var(--line); border-radius: 10px; transition: border-color 0.15s, transform 0.12s; }
   .see-all span { transition: transform 0.12s; }
@@ -207,7 +206,7 @@ const isHome = Astro.url.pathname === "/";
   .botlinks { font-family: "JetBrains Mono", monospace; font-size: 12px; letter-spacing: 0.1em; text-transform: uppercase; color: var(--faint); }
   .botlinks a { color: var(--cyan); text-decoration: none; }
   .botlinks span { margin: 0 9px; opacity: 0.5; }
-  @media (max-width: 900px) { .mini-mosaic, .footer-panels { grid-template-columns: 1fr; } }
+  @media (max-width: 900px) { .footer-panels { grid-template-columns: 1fr; } }
   @media (max-width: 820px) { .hero { grid-template-columns: 1fr; gap: 36px; justify-items: center; } .htext { text-align: center; } .bio { margin-left: auto; margin-right: auto; max-width: 620px; } .findme { justify-content: center; } .portrait-stage { order: -1; } .frame.duo { width: 300px; } }
   @media (max-width: 720px) { .hero h2 { font-size: 48px; } }
 </style>

--- a/src/components/Footer.astro
+++ b/src/components/Footer.astro
@@ -6,7 +6,10 @@ import StickerCard from "./StickerCard.astro";
 import portrait from "../assets/perry_weather.jpg";
 
 const allPosts = await getSortedPosts();
-const latest = allPosts.slice(0, 3);
+const currentPath = Astro.url.pathname.replace(/\/$/, "");
+const latest = allPosts
+  .filter((post) => `/${post.collection}/${post.slug}` !== currentPath)
+  .slice(0, 3);
 const duos = [4, 6, 5];
 const isHome = Astro.url.pathname === "/";
 ---
@@ -72,6 +75,9 @@ const isHome = Astro.url.pathname === "/";
             </div>
             <div class="mini-mosaic">
               {latest.map((post, i) => <StickerCard post={post} duo={duos[i % duos.length]} />)}
+            </div>
+            <div class="see-all-row">
+              <a class="see-all" href="/posts">All posts <span aria-hidden="true">→</span></a>
             </div>
           </section>
 
@@ -169,8 +175,14 @@ const isHome = Astro.url.pathname === "/";
   .frame.duo .tape { position: absolute; z-index: 4; bottom: 12px; left: 50%; transform: translateX(-50%); font-family: "JetBrains Mono", monospace; font-weight: 700; font-size: 12px; letter-spacing: 0.1em; color: var(--badge-ink); background: var(--gold); padding: 5px 11px; border-radius: 7px; white-space: nowrap; }
   .frame.duo .starbadge { position: absolute; z-index: 5; top: -16px; right: -12px; }
   .frame.duo .starbadge path { fill: var(--gold); stroke: var(--surface); stroke-width: 1.2; }
-  .home-footer-grid { display: grid; gap: 38px; margin-top: 0; }
+  .home-footer-grid { display: grid; gap: 18px; margin-top: 0; }
+  .home-footer-grid .sec-head { margin-top: 34px; }
   .mini-mosaic { display: grid; grid-template-columns: repeat(3, minmax(0, 1fr)); gap: 18px; }
+  .see-all-row { display: flex; justify-content: flex-end; margin-top: 22px; }
+  .see-all { display: inline-flex; align-items: center; gap: 8px; margin: 0; font-family: "JetBrains Mono", monospace; font-size: 12px; font-weight: 700; letter-spacing: 0.08em; text-transform: uppercase; color: var(--cyan); text-decoration: none; padding: 9px 15px; border: 2px solid var(--line); border-radius: 10px; transition: border-color 0.15s, transform 0.12s; }
+  .see-all span { transition: transform 0.12s; }
+  .see-all:hover { border-color: var(--cyan); }
+  .see-all:hover span { transform: translateX(3px); }
   .footer-panels { display: grid; grid-template-columns: 1fr 1fr; gap: 24px; }
   .panel { background: var(--surface); border: 2px solid var(--line); border-radius: 18px; padding: 24px 26px; box-shadow: 5px 5px 0 rgba(0, 0, 0, 0.28); }
   .panel h4 { font-size: 17px; text-transform: uppercase; letter-spacing: -0.01em; margin: 0 0 16px; display: flex; align-items: center; gap: 10px; }
@@ -184,6 +196,7 @@ const isHome = Astro.url.pathname === "/";
   .panel li a:hover { text-decoration: underline; }
   .panel li .m { color: var(--muted); font-weight: 400; }
   .foot-inner { max-width: 1080px; margin: 0 auto; padding: 42px 24px 50px; text-align: center; }
+  .home-foot .foot-inner { max-width: none; margin-top: 16px; padding: 32px var(--page-gutter) 40px; border-top: 2px solid var(--line); background: var(--bg); }
   .made { font-size: 16px; color: var(--muted); }
   .made b { color: var(--ink); font-weight: 700; }
   .social { display: flex; gap: 14px; justify-content: center; margin: 20px 0 16px; }

--- a/src/components/Footer.astro
+++ b/src/components/Footer.astro
@@ -22,22 +22,22 @@ const isHome = Astro.url.pathname === "/";
 
         <div class="home-footer-hero">
           <div class="home-footer-copy">
-            <p class="eyebrow">The footer is the homepage now</p>
+            <p class="eyebrow">// a serious &amp; professional website</p>
             <h2 id="home-footer-title">
               Brian <span>Perry</span>.dev
             </h2>
             <p>
               I'm a <a href="https://github.com/backlineint">web developer</a> figuring out
-              what AI agents are actually good for at <a href="https://actual.ai">Actual AI</a>,
-              a longtime <a href="https://www.drupal.org/u/brianperry">Drupal person</a>,
-              occasional <a href="https://noti.st/brianperry">conference speaker</a>,
-              Chicago suburbs dad, and Nintendo enjoyer. Basically the whole homepage, but hiding
-              in the footer like a raccoon with a LinkedIn profile.
+              what AI agents are actually good for - at <a href="https://actual.ai">Actual AI</a>
+              by day, and in a pile of side projects the rest of the time. I'm a longtime
+              <a href="https://www.drupal.org/u/brianperry">member of the Drupal community</a>
+              and I often <a href="https://noti.st/brianperry">present</a> at tech events. I
+              live with a super awesome family in the Chicago suburbs and I'm really into
+              Nintendo.
             </p>
             <div class="footer-actions">
-              <a href="/">Home base</a>
-              <a href="/about">About</a>
-              <a href="/posts">All posts</a>
+              <a href="https://bsky.app/profile/brianperry.dev" target="_blank">Bluesky</a>
+              <a href="https://github.com/backlineint" target="_blank">GitHub</a>
               <a href="/feed.xml">RSS</a>
             </div>
           </div>
@@ -69,10 +69,41 @@ const isHome = Astro.url.pathname === "/";
               <h3 id="home-footer-play">Work &amp; Play</h3>
               <span></span>
             </div>
-            <div class="panel-list">
-              <a href="https://actual.ai"><b>Actual AI</b><small>Guardrails for AI-powered software development.</small></a>
-              <a href="https://github.com/backlineint/brianperry.dev"><b>brianperry.dev</b><small>Rebuilt more times than is reasonable.</small></a>
-              <a href="https://www.yachtclubgames.com/games/mina-the-hollower/"><b>Mina the Hollower</b><small>Game Boy Color Zelda energy from the Shovel Knight team.</small></a>
+            <div class="footer-panels">
+              <div class="panel">
+                <h4><span class="badge gold tag">BUILD</span>Recent Projects</h4>
+                <ul>
+                  <li>
+                    <span class="ic" style="background:var(--gold)"></span>
+                    <span><a href="https://actual.ai">Actual AI</a> <span class="m">— guardrails for AI-powered software development.</span></span>
+                  </li>
+                  <li>
+                    <span class="ic" style="background:var(--cyan)"></span>
+                    <span><b>Stealth Read Later App</b> <span class="m">— side project city. More to come soon.</span></span>
+                  </li>
+                  <li>
+                    <span class="ic" style="background:var(--red)"></span>
+                    <span><a href="https://github.com/backlineint/brianperry.dev">brianperry.dev</a> <span class="m">— rebuilt more times than is reasonable.</span></span>
+                  </li>
+                </ul>
+              </div>
+              <div class="panel">
+                <h4><span class="badge green tag">1-UP</span>Currently Enjoying</h4>
+                <ul>
+                  <li>
+                    <span class="ic" style="background:var(--gold)"></span>
+                    <span><a href="https://www.imdb.com/title/tt33332385/">Widows Bay</a> <span class="m">— quirky horror-comedy series and proof that all of New England is haunted.</span></span>
+                  </li>
+                  <li>
+                    <span class="ic" style="background:var(--cyan)"></span>
+                    <span><a href="https://www.yachtclubgames.com/games/mina-the-hollower/">Mina the Hollower</a> <span class="m">— a take on Game Boy Color era Zelda from the Shovel Knight team.</span></span>
+                  </li>
+                  <li>
+                    <span class="ic" style="background:var(--red)"></span>
+                    <span><a href="https://open.spotify.com/album/4I3Ea3ZOeHI9lmKd2Pyact">The Obsessives</a> <span class="m">— keep coming back to this indie rock album that randomly came up in my autoplay.</span></span>
+                  </li>
+                </ul>
+              </div>
             </div>
           </section>
         </div>
@@ -106,20 +137,28 @@ const isHome = Astro.url.pathname === "/";
   h2 span { color: var(--red); }
   .home-footer-copy > p:not(.eyebrow) { max-width: 670px; color: var(--muted); font-size: 18px; }
   .footer-actions { display: flex; flex-wrap: wrap; gap: 10px; margin-top: 22px; }
-  .footer-actions a, .panel-list a { border: 2px solid var(--line); border-radius: 12px; background: var(--surface); color: var(--ink); text-decoration: none; transition: transform .12s, border-color .12s; }
+  .footer-actions a { border: 2px solid var(--line); border-radius: 12px; background: var(--surface); color: var(--ink); text-decoration: none; transition: transform .12s, border-color .12s; }
   .footer-actions a { padding: 9px 14px; font-family: var(--font-mono); font-size: 12px; font-weight: 700; letter-spacing: .08em; text-transform: uppercase; }
-  .footer-actions a:hover, .panel-list a:hover { transform: translate(-1px, -1px); border-color: var(--cyan); }
+  .footer-actions a:hover { transform: translate(-1px, -1px); border-color: var(--cyan); }
   .portrait-card { position: relative; display: block; transform: rotate(3deg); color: var(--badge-ink); text-decoration: none; }
   .portrait-card :global(img) { display: block; border: 6px solid var(--surface); border-radius: 18px; box-shadow: 7px 7px 0 var(--duo-frame-shadow); }
   .portrait-card span { position: absolute; left: 50%; bottom: 13px; transform: translateX(-50%); padding: 4px 10px; border-radius: 7px; background: var(--gold); font-family: var(--font-mono); font-size: 11px; font-weight: 700; letter-spacing: .1em; }
-  .home-footer-grid { display: grid; grid-template-columns: minmax(0, 2fr) minmax(260px, 1fr); gap: 28px; margin-top: 38px; }
+  .home-footer-grid { display: grid; gap: 38px; margin-top: 38px; }
   .section-head h3 { margin: 0; font-size: 22px; color: var(--ink); }
   .section-head span { flex: 1; height: 2px; background: var(--line); }
   .mini-mosaic { display: grid; grid-template-columns: repeat(3, minmax(0, 1fr)); gap: 18px; }
-  .panel-list { display: grid; gap: 14px; }
-  .panel-list a { display: grid; gap: 4px; padding: 18px; }
-  .panel-list b { color: var(--gold); }
-  .panel-list small { color: var(--muted); line-height: 1.4; }
+  .footer-panels { display: grid; grid-template-columns: 1fr 1fr; gap: 24px; }
+  .panel { background: var(--surface); border: 2px solid var(--line); border-radius: 18px; padding: 24px 26px; box-shadow: 5px 5px 0 rgba(0, 0, 0, 0.28); }
+  .panel h4 { font-size: 17px; text-transform: uppercase; letter-spacing: -0.01em; margin: 0 0 16px; display: flex; align-items: center; gap: 10px; }
+  .panel h4 .tag { font-size: 10px; }
+  .panel ul { list-style: none; margin: 0; padding: 0; }
+  .panel li { padding: 12px 0; border-top: 1.5px solid var(--line-2); font-size: 15.5px; line-height: 1.45; display: flex; gap: 12px; align-items: baseline; }
+  .panel li:first-child { border-top: none; padding-top: 0; }
+  .panel .ic { flex: 0 0 auto; width: 8px; height: 8px; border-radius: 2px; align-self: flex-start; margin-top: 7px; }
+  .panel li b { color: var(--ink); }
+  .panel li a { color: var(--cyan); font-weight: 700; text-decoration: none; }
+  .panel li a:hover { text-decoration: underline; }
+  .panel li .m { color: var(--muted); font-weight: 400; }
   .foot-inner { max-width: 1080px; margin: 0 auto; padding: 42px 24px 50px; text-align: center; }
   .made { font-size: 16px; color: var(--muted); }
   .made b { color: var(--ink); font-weight: 700; }
@@ -131,5 +170,5 @@ const isHome = Astro.url.pathname === "/";
   .botlinks { font-family: "JetBrains Mono", monospace; font-size: 12px; letter-spacing: 0.1em; text-transform: uppercase; color: var(--faint); }
   .botlinks a { color: var(--cyan); text-decoration: none; }
   .botlinks span { margin: 0 9px; opacity: 0.5; }
-  @media (max-width: 900px) { .home-footer-hero, .home-footer-grid { grid-template-columns: 1fr; } .portrait-card { max-width: 220px; justify-self: center; } .mini-mosaic { grid-template-columns: 1fr; } }
+  @media (max-width: 900px) { .home-footer-hero { grid-template-columns: 1fr; } .portrait-card { max-width: 220px; justify-self: center; } .mini-mosaic, .footer-panels { grid-template-columns: 1fr; } }
 </style>

--- a/src/components/Footer.astro
+++ b/src/components/Footer.astro
@@ -15,18 +15,11 @@ const isHome = Astro.url.pathname === "/";
   {
     !isHome && (
       <section class="home-footer" aria-labelledby="home-footer-title">
-        <div class="home-footer-kicker">
-          <span>// you made it to the bottom</span>
-          <ButtonCluster />
-        </div>
-
-        <div class="home-footer-hero">
-          <div class="home-footer-copy">
-            <p class="eyebrow">// a serious &amp; professional website</p>
-            <h2 id="home-footer-title">
-              Brian <span>Perry</span>.dev
-            </h2>
-            <p>
+        <header class="hero" aria-labelledby="home-footer-title">
+          <div class="htext">
+            <span class="eyebrow">// a serious &amp; professional website</span>
+            <h2 id="home-footer-title">Brian <span class="pink">Perry</span>.dev<span class="caret" aria-hidden="true">_</span></h2>
+            <p class="bio">
               I'm a <a href="https://github.com/backlineint">web developer</a> figuring out
               what AI agents are actually good for - at <a href="https://actual.ai">Actual AI</a>
               by day, and in a pile of side projects the rest of the time. I'm a longtime
@@ -35,29 +28,47 @@ const isHome = Astro.url.pathname === "/";
               live with a super awesome family in the Chicago suburbs and I'm really into
               Nintendo.
             </p>
-            <div class="footer-actions">
-              <a href="https://bsky.app/profile/brianperry.dev" target="_blank">Bluesky</a>
-              <a href="https://github.com/backlineint" target="_blank">GitHub</a>
-              <a href="/feed.xml">RSS</a>
+            <div class="findme">
+              <a href="https://bsky.app/profile/brianperry.dev" target="_blank">
+                <svg viewBox="0 0 576 512" aria-hidden="true"><path fill="currentColor" d="M407.8 294.7c-3.3-.4-6.7-.8-10-1.3c3.4.4 6.7.9 10 1.3M288 227.1c-26.1-50.7-97.1-145.2-163.1-191.8C61.6-9.4 37.5-1.7 21.6 5.5C3.3 13.8 0 41.9 0 58.4S9.1 194 15 213.9c19.5 65.7 89.1 87.9 153.2 80.7c3.3-.5 6.6-.9 10-1.4c-3.3.5-6.6 1-10 1.4c-93.9 14-177.3 48.2-67.9 169.9C220.6 589.1 265.1 437.8 288 361.1c22.9 76.7 49.2 222.5 185.6 103.4c102.4-103.4 28.1-156-65.8-169.9c-3.3-.4-6.7-.8-10-1.3c3.4.4 6.7.9 10 1.3c64.1 7.1 133.6-15.1 153.2-80.7C566.9 194 576 75 576 58.4s-3.3-44.7-21.6-52.9c-15.8-7.1-40-14.9-103.2 29.8C385.1 81.9 314.1 176.4 288 227.1"/></svg>
+                Bluesky
+              </a>
+              <a href="https://github.com/backlineint" target="_blank">
+                <svg viewBox="0 0 16 16" aria-hidden="true"><path fill="currentColor" d="M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82.64-.18 1.32-.27 2-.27.68 0 1.36.09 2 .27 1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55.38A8.012 8.012 0 0 0 16 8c0-4.42-3.58-8-8-8z"/></svg>
+                GitHub
+              </a>
+              <a href="/feed.xml">
+                <svg viewBox="0 0 24 24" aria-hidden="true"><path fill="currentColor" d="M5 19a2 2 0 1 0 0-4 2 2 0 0 0 0 4ZM3 9.5V13c4.4 0 8 3.6 8 8h3.5C14.5 14.6 9.4 9.5 3 9.5Zm0-6V7c7.7 0 14 6.3 14 14h3.5C20.5 11.6 12.4 3.5 3 3.5Z"/></svg>
+                RSS
+              </a>
             </div>
           </div>
 
-          <a class="portrait-card" href="/about" aria-label="About Brian Perry">
-            <Image
-              src={portrait}
-              alt="Brian with a weather station"
-              width={360}
-              height={402}
-            />
-            <span>// brian</span>
-          </a>
-        </div>
+          <div class="portrait-stage">
+            <a class="frame duo" href="/about" aria-label="About Brian Perry">
+              <div class="duo-clip">
+                <Image
+                  src={portrait}
+                  alt="Brian with a weather station"
+                  width={600}
+                  height={668}
+                />
+                <div class="ov holo"></div>
+              </div>
+              <span class="tape">// brian</span>
+              <svg class="starbadge" width="50" height="50" viewBox="0 0 24 24" aria-hidden="true">
+                <path d="M12 0C13 7 17 11 24 12 17 13 13 17 12 24 11 17 7 13 0 12 7 11 11 7 12 0Z" />
+              </svg>
+            </a>
+          </div>
+        </header>
 
         <div class="home-footer-grid">
           <section class="latest-block" aria-labelledby="home-footer-latest">
-            <div class="section-head">
-              <h3 id="home-footer-latest">Latest</h3>
-              <span></span>
+            <div class="sec-head">
+              <h2 id="home-footer-latest">Latest</h2>
+              <span class="line"></span>
+              <ButtonCluster />
             </div>
             <div class="mini-mosaic">
               {latest.map((post, i) => <StickerCard post={post} duo={duos[i % duos.length]} />)}
@@ -65,9 +76,10 @@ const isHome = Astro.url.pathname === "/";
           </section>
 
           <section class="play-block" aria-labelledby="home-footer-play">
-            <div class="section-head">
-              <h3 id="home-footer-play">Work &amp; Play</h3>
-              <span></span>
+            <div class="sec-head">
+              <h2 id="home-footer-play">Work &amp; Play</h2>
+              <span class="line"></span>
+              <ButtonCluster />
             </div>
             <div class="footer-panels">
               <div class="panel">
@@ -128,24 +140,36 @@ const isHome = Astro.url.pathname === "/";
 </footer>
 <style>
   .foot { margin-top: var(--footer-gap, 76px); border-top: 2px solid var(--line); background: var(--bg-2); }
-  .home-foot { border-top: 0; background: linear-gradient(180deg, transparent, var(--bg-2) 14%); }
-  .home-footer { width: min(1080px, 100%); margin: 0 auto; padding: 64px var(--page-gutter) 30px; }
-  .home-footer-kicker, .section-head { display: flex; align-items: center; gap: 14px; margin-bottom: 22px; font-family: var(--font-mono); font-size: 12px; letter-spacing: .12em; text-transform: uppercase; color: var(--cyan); }
-  .home-footer-hero { display: grid; grid-template-columns: minmax(0, 1fr) 210px; gap: 36px; align-items: center; padding: 30px; border: 2px solid var(--line); border-radius: 24px; background: color-mix(in srgb, var(--surface) 78%, transparent); box-shadow: var(--box-shadow); }
-  .eyebrow { margin: 0 0 10px; font-family: var(--font-mono); font-size: 12px; letter-spacing: .16em; text-transform: uppercase; color: var(--gold); }
-  h2 { font-size: clamp(40px, 6vw, 72px); line-height: .9; text-transform: uppercase; margin: 0; }
-  h2 span { color: var(--red); }
-  .home-footer-copy > p:not(.eyebrow) { max-width: 670px; color: var(--muted); font-size: 18px; }
-  .footer-actions { display: flex; flex-wrap: wrap; gap: 10px; margin-top: 22px; }
-  .footer-actions a { border: 2px solid var(--line); border-radius: 12px; background: var(--surface); color: var(--ink); text-decoration: none; transition: transform .12s, border-color .12s; }
-  .footer-actions a { padding: 9px 14px; font-family: var(--font-mono); font-size: 12px; font-weight: 700; letter-spacing: .08em; text-transform: uppercase; }
-  .footer-actions a:hover { transform: translate(-1px, -1px); border-color: var(--cyan); }
-  .portrait-card { position: relative; display: block; transform: rotate(3deg); color: var(--badge-ink); text-decoration: none; }
-  .portrait-card :global(img) { display: block; border: 6px solid var(--surface); border-radius: 18px; box-shadow: 7px 7px 0 var(--duo-frame-shadow); }
-  .portrait-card span { position: absolute; left: 50%; bottom: 13px; transform: translateX(-50%); padding: 4px 10px; border-radius: 7px; background: var(--gold); font-family: var(--font-mono); font-size: 11px; font-weight: 700; letter-spacing: .1em; }
-  .home-footer-grid { display: grid; gap: 38px; margin-top: 38px; }
-  .section-head h3 { margin: 0; font-size: 22px; color: var(--ink); }
-  .section-head span { flex: 1; height: 2px; background: var(--line); }
+  .home-foot { margin-top: 36px; border-top: 2px solid var(--line); background: var(--bg-2); }
+  .home-footer { width: min(1080px, 100%); margin: 0 auto; padding: 36px var(--page-gutter) 30px; }
+  .hero { max-width: 1080px; margin: 0 auto; padding: 26px 0 6px; position: relative; display: grid; grid-template-columns: 0.88fr 1.12fr; gap: 56px; align-items: center; }
+  .htext { text-align: left; }
+  .eyebrow { font-family: "JetBrains Mono", monospace; font-size: 13px; font-weight: 700; letter-spacing: 0.2em; text-transform: uppercase; color: var(--cyan); }
+  .hero h2 { font-size: 62px; line-height: 0.92; letter-spacing: -0.035em; margin: 16px 0 0; text-transform: uppercase; }
+  .hero h2 .caret { color: var(--cyan); margin-left: 0.04em; animation: caret-blink 1.05s step-end infinite; }
+  @keyframes caret-blink { 0% { opacity: 1; } 50% { opacity: 0; } }
+  @media (prefers-reduced-motion: reduce) { .hero h2 .caret { animation: none; } }
+  .bio { max-width: 560px; margin: 22px 0 0; color: var(--muted); font-size: 18px; line-height: 1.6; text-wrap: pretty; }
+  .bio a { color: var(--cyan); text-decoration: underline; text-decoration-color: rgba(70, 212, 234, 0.5); text-decoration-thickness: 2px; text-underline-offset: 3px; }
+  .findme { display: flex; flex-wrap: wrap; gap: 12px; justify-content: flex-start; margin: 28px 0 0; }
+  .findme a { display: inline-flex; align-items: center; gap: 9px; font-weight: 600; font-size: 14.5px; color: var(--ink); background: var(--surface); border: 2px solid var(--line); border-radius: 12px; padding: 10px 16px; text-decoration: none; box-shadow: 3px 3px 0 rgba(0, 0, 0, 0.3); transition: transform 0.12s, box-shadow 0.12s, border-color 0.12s; }
+  .findme a:hover { transform: translate(-1px, -1px); box-shadow: 5px 5px 0 rgba(0, 0, 0, 0.3); border-color: var(--cyan); }
+  .findme svg { width: 17px; height: 17px; fill: var(--gold); color: var(--gold); }
+  .portrait-stage { display: flex; justify-content: center; order: -1; }
+  .frame.duo { display: block; position: relative; width: 100%; max-width: 380px; aspect-ratio: 5 / 6; border-radius: 20px; border: 7px solid var(--surface); box-shadow: 8px 10px 0 var(--duo-frame-shadow); transform: rotate(-3deg); transition: transform 0.2s; text-decoration: none; color: inherit; }
+  .frame.duo:hover, .frame.duo:focus-visible { transform: rotate(0deg) scale(1.015); }
+  .frame.duo:focus-visible { outline: 3px solid var(--cyan); outline-offset: 4px; }
+  .duo-clip { position: absolute; inset: 0; border-radius: 13px; overflow: hidden; isolation: isolate; }
+  .duo-clip :global(img) { display: block; width: 100%; height: 100%; object-fit: cover; border-radius: 0; filter: saturate(1.03); }
+  .duo-clip .ov { position: absolute; inset: 0; pointer-events: none; opacity: 0; transition: opacity 0.3s ease; }
+  .duo-clip .ov.holo { background: linear-gradient(125deg, rgba(255, 255, 255, 0) 12%, rgba(255, 120, 190, 0.55) 26%, rgba(125, 205, 255, 0.55) 38%, rgba(160, 255, 200, 0.55) 50%, rgba(255, 228, 135, 0.55) 62%, rgba(206, 150, 255, 0.55) 74%, rgba(255, 255, 255, 0) 88%); background-size: 200% 200%; mix-blend-mode: color-dodge; }
+  .frame.duo:hover .ov.holo, .frame.duo:focus-visible .ov.holo { animation: holo-glint 2.6s ease-out infinite; }
+  @keyframes holo-glint { 0% { opacity: 0; background-position: 0% 50%; } 4% { opacity: 0.5; } 18% { opacity: 0.52; background-position: 65% 50%; } 27% { opacity: 0; background-position: 100% 50%; } 100% { opacity: 0; background-position: 100% 50%; } }
+  @media (prefers-reduced-motion: reduce) { .frame.duo:hover .ov.holo, .frame.duo:focus-visible .ov.holo { animation: none; } }
+  .frame.duo .tape { position: absolute; z-index: 4; bottom: 12px; left: 50%; transform: translateX(-50%); font-family: "JetBrains Mono", monospace; font-weight: 700; font-size: 12px; letter-spacing: 0.1em; color: var(--badge-ink); background: var(--gold); padding: 5px 11px; border-radius: 7px; white-space: nowrap; }
+  .frame.duo .starbadge { position: absolute; z-index: 5; top: -16px; right: -12px; }
+  .frame.duo .starbadge path { fill: var(--gold); stroke: var(--surface); stroke-width: 1.2; }
+  .home-footer-grid { display: grid; gap: 38px; margin-top: 0; }
   .mini-mosaic { display: grid; grid-template-columns: repeat(3, minmax(0, 1fr)); gap: 18px; }
   .footer-panels { display: grid; grid-template-columns: 1fr 1fr; gap: 24px; }
   .panel { background: var(--surface); border: 2px solid var(--line); border-radius: 18px; padding: 24px 26px; box-shadow: 5px 5px 0 rgba(0, 0, 0, 0.28); }
@@ -170,5 +194,7 @@ const isHome = Astro.url.pathname === "/";
   .botlinks { font-family: "JetBrains Mono", monospace; font-size: 12px; letter-spacing: 0.1em; text-transform: uppercase; color: var(--faint); }
   .botlinks a { color: var(--cyan); text-decoration: none; }
   .botlinks span { margin: 0 9px; opacity: 0.5; }
-  @media (max-width: 900px) { .home-footer-hero { grid-template-columns: 1fr; } .portrait-card { max-width: 220px; justify-self: center; } .mini-mosaic, .footer-panels { grid-template-columns: 1fr; } }
+  @media (max-width: 900px) { .mini-mosaic, .footer-panels { grid-template-columns: 1fr; } }
+  @media (max-width: 820px) { .hero { grid-template-columns: 1fr; gap: 36px; justify-items: center; } .htext { text-align: center; } .bio { margin-left: auto; margin-right: auto; max-width: 620px; } .findme { justify-content: center; } .portrait-stage { order: -1; } .frame.duo { width: 300px; } }
+  @media (max-width: 720px) { .hero h2 { font-size: 48px; } }
 </style>


### PR DESCRIPTION
### Motivation
- Implement the idea that every page’s footer can act like a compact homepage, surfacing the hero, bio, recent posts, and quick links at the bottom of non-home pages to encourage exploration.

### Description
- Replace the simple footer with a component-driven homepage-style footer in `src/components/Footer.astro` that conditionally renders the expanded content when `Astro.url.pathname !== '/'`.
- Add server-side logic to fetch recent posts via `getSortedPosts()` and render `StickerCard` items, and wire up `ButtonCluster` plus a portrait image using `astro:assets`.
- Preserve the existing social / made-with row and append responsive styles for the new `.home-footer`, `.home-footer-grid`, portrait card, mini-mosaic, and action panels.
- Keep the change self-contained to `Footer.astro` (imports, markup, and CSS) and reuse existing components/asset paths.

### Testing
- Ran `pnpm build` (which runs `astro check && astro build`) and received `0 errors` from the type/check step and a successful static build with pages generated.
- Validated the expanded footer was rendered on a non-home page by running `curl -L -s http://127.0.0.1:4321/about/ | rg -n "The footer is the homepage now|you made it to the bottom|Latest|Work &amp; Play"`, which found the expected sections.
- Attempted to capture a screenshot via Playwright but Playwright was not available in the environment and fetching it failed, so no automated screenshot was produced.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a45736a7e60832ba58d092803e3f6a9)