### PR TITLE
Let card and row text use the full width, and name More Later

### DIFF
--- a/src/components/Cartridge.astro
+++ b/src/components/Cartridge.astro
@@ -134,7 +134,9 @@ const badges = (tags && tags.length ? tags : [collection]).slice(0, 2);
     font-size: 14.5px;
     line-height: 1.45;
     margin: 0;
-    max-width: 64ch;
+    /* Chrome's default paragraph prettifying narrows this to well under the
+       row, leaving a gap on the right — pin it back to the row's width. */
+    max-width: 100%;
   }
   .cart-tags {
     display: flex;

--- a/src/components/Footer.astro
+++ b/src/components/Footer.astro
@@ -96,7 +96,7 @@ const isHome = Astro.url.pathname === "/";
                   </li>
                   <li>
                     <span class="ic" style="background:var(--cyan)"></span>
-                    <span><b>Stealth Read Later App</b> <span class="m">— side project city. More to come soon.</span></span>
+                    <span><a href="https://www.morelater.app">More Later</a> <span class="m">— a reading queue that decides with you. Beta opening soon.</span></span>
                   </li>
                   <li>
                     <span class="ic" style="background:var(--red)"></span>

--- a/src/components/StickerCard.astro
+++ b/src/components/StickerCard.astro
@@ -164,6 +164,13 @@ const badges = (tags && tags.length ? tags : [collection]).slice(0, 2);
   .scard.feat h3 {
     font-size: 30px;
   }
+  /* The featured card spans the full grid width. Chrome's default heading
+     balancing narrows the title and description to well under the card,
+     leaving the right half empty — pin them back to the card's width. */
+  .scard.feat h3,
+  .scard.feat p {
+    max-width: 100%;
+  }
   h3 a {
     color: var(--ink);
     text-decoration: none;

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -111,7 +111,7 @@ const duos = [1, 3, 2, 4, 6, 5];
             </li>
             <li>
               <span class="ic" style="background:var(--cyan)"></span>
-              <span><b>Stealth Read Later App</b> <span class="m">— side project city. More to come soon.</span></span>
+              <span><a href="https://www.morelater.app">More Later</a> <span class="m">— a reading queue that decides with you. Beta opening soon.</span></span>
             </li>
             <li>
               <span class="ic" style="background:var(--red)"></span>


### PR DESCRIPTION
## What changed

Two small CSS fixes plus a copy update.

**Text width on cards and rows.** The featured card on the home page and the cartridge rows (recent list on `/posts`, Latest block in the footer) were only using about 60% of their available width.

The cause is Chrome's default text balancing: it applies `text-wrap: balance` to headings and `pretty` to paragraphs, and implements that by imposing an internal `max-width` on the element. On normal-width cards that's invisible, but on the wide featured card it clamped the title to 700px and the description to 596px inside a 996px content box. `Cartridge` had the same problem, compounded by an authored `max-width: 64ch` on `.cart-desc`.

An author-declared `max-width: 100%` beats the balancing width, so both now fill their container. `text-wrap` is left at its default, so longer text still wraps gracefully.

**Recent Projects copy.** "Stealth Read Later App — side project city. More to come soon." becomes "More Later — a reading queue that decides with you. Beta opening soon.", linked to https://www.morelater.app. Updated in both places it appears (home page panel and footer).

## Verification

Measured in the browser preview at a 1280px viewport, before → after:

| Element | before | after |
|---|---|---|
| Featured card title | 700px | 996px |
| Featured card description | 596px, 2 lines | 996px, one 935px line |
| Cartridge row (777px body) | 550 + 65 | 619, one line |
| Cartridge row (939px body) | 588 + 371 | 812 + 147 |
| Footer Latest row (939px body) | ~558 | 874, one line |

Checked visually on the home page, `/posts`, and the `feat-hero` variant. The featured card also got 24px shorter. No console errors.

One caveat: the browser pane's screenshot capture kept returning blank frames when scrolled deep into a page, so the footer Latest block was verified by DOM measurement rather than a screenshot. It's the same `Cartridge` component at the same widths as the rows that were confirmed visually.

## Notes for review

The `max-width: 100%` trades away the browser's orphan avoidance — it can no longer shrink earlier lines to lengthen a short last line. In practice a couple of rows now end with a short trailing fragment (e.g. a 147px last line). That seemed like the right trade for filling the width, but worth a look.

🤖 Generated with [Claude Code](https://claude.com/claude-code)